### PR TITLE
Added Drunken Master Support

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
@@ -96,6 +96,9 @@
             <DataTrigger Binding="{Binding SubclassIDString}" Value="Hexblade">
                 <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/Hexblade/ClassIcons/warlock_Hexblade.png"/>
             </DataTrigger>
+			<DataTrigger Binding="{Binding SubclassIDString}" Value="DrunkenMaster">
+                <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;componentAssets/drunkenmaster/ClassIcons/monk_drunkenmaster.png"/>
+            </DataTrigger>
         </Style.Triggers>
 	</Style>
 	
@@ -183,6 +186,9 @@
             <DataTrigger Binding="{Binding SubclassIDString}" Value="Hexblade">
                 <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/Hexblade/ClassIcons/hotbar/warlock_Hexblade.png"/>
             </DataTrigger>
+			<DataTrigger Binding="{Binding SubclassIDString}" Value="DrunkenMaster">
+                <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/drunkenmaster/ClassIcons/hotbar/monk_drunkenmaster.png"/>
+			</DataTrigger>
         </Style.Triggers>
     </Style>
 

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
@@ -97,7 +97,7 @@
                 <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/Hexblade/ClassIcons/warlock_Hexblade.png"/>
             </DataTrigger>
 			<DataTrigger Binding="{Binding SubclassIDString}" Value="DrunkenMaster">
-                <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;componentAssets/drunkenmaster/ClassIcons/monk_drunkenmaster.png"/>
+                <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/drunkenmaster/ClassIcons/monk_drunkenmaster.png"/>
             </DataTrigger>
         </Style.Triggers>
 	</Style>


### PR DESCRIPTION
-Added DataTriggers for Drunken Master Subclass to IUI_Classicons.xaml 

I went to go edit my old pr, and seen you removed most of the icons from assets. This caused headaches for me though because git might as well be a foreign language, and I proved unable to figure out what in the hell I'm doing. I'm assuming the DDS files are now stored locally on my own mod. 

Will change anything you need me to. 