### PR TITLE
Dynamically display icons based on ID

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
@@ -10,11 +10,34 @@
                     xmlns:noesis="clr-namespace:NoesisGUIExtensions;assembly=Noesis.GUI.Extensions"
 					mc:Ignorable="d">
 
+    <BitmapImage x:Key="IUI_GenericClassHotbarIcon" UriSource="pack://application:,,,/GustavNoesisGUI;component/Assets/ClassIcons/hotbar/generic.png"/>
+    <!-- This is a generic icon for mods with no class icons provided. TODO: Change to an icon included in ImprovedUI? -->
+    <BitmapImage x:Key="IUI_GenericClassMainIcon" UriSource="pack://application:,,,/GustavNoesisGUI;component/Assets/Artificer/ClassIcons/generic.png"/>
+
 	<!-- This is the icon that appears in the top right of the CC screen/shows in character sheet when the class/subclass is selected -->
 	<Style x:Key="IUI_MainClassIconStyle" TargetType="Image" >
-		<!-- This is a generic icon for mods with no class icons provided -->
-        <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/Artificer/ClassIcons/generic.png"/>
         <Style.Triggers>
+            <!-- Dynamically try and find an image by the class ID in the regular Larian folder -->
+           <DataTrigger Binding="{Binding SubclassIDString, Converter={StaticResource NullToBoolTrueConverter}, ConverterParameter='EmptyString'}" Value="False">
+                <Setter Property="Source">
+                    <Setter.Value>
+                        <MultiBinding Converter="{StaticResource IconIdToSourceConverter}" FallbackValue="{StaticResource IUI_GenericClassMainIcon}">
+                            <Binding Source="Assets/ClassIcons/"/>
+                            <Binding Path="SubclassIDString"/>
+                        </MultiBinding>
+                    </Setter.Value>
+                </Setter>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding SubclassIDString, Converter={StaticResource NullToBoolTrueConverter}, ConverterParameter='EmptyString'}" Value="True">
+                <Setter Property="Source">
+                    <Setter.Value>
+                        <MultiBinding Converter="{StaticResource IconIdToSourceConverter}" FallbackValue="{StaticResource IUI_GenericClassMainIcon}">
+                            <Binding Source="Assets/ClassIcons/"/>
+                            <Binding Path="IDString"/>
+                        </MultiBinding>
+                    </Setter.Value>
+                </Setter>
+            </DataTrigger>
             <!--<DataTrigger Binding="{Binding IDString}" Value="Barbarian">
                 <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/ClassIcons/barbarian.png"/>
             </DataTrigger> -->
@@ -105,6 +128,27 @@
 	<!-- This is the icon that appears as an option when choosing class/subclass in CC/shows in bottom left of hotbar -->
 	<Style x:Key="IUI_MainClassIconHotbarStyle" TargetType="Image" >
         <Style.Triggers>
+            <!-- Dynamically try and find an image by the class ID in the regular Larian folder -->
+           <DataTrigger Binding="{Binding SubclassIDString, Converter={StaticResource NullToBoolTrueConverter}, ConverterParameter='EmptyString'}" Value="False">
+                <Setter Property="Source">
+                    <Setter.Value>
+                        <MultiBinding Converter="{StaticResource IconIdToSourceConverter}" FallbackValue="{StaticResource IUI_GenericClassHotbarIcon}">
+                            <Binding Source="Assets/ClassIcons/hotbar/"/>
+                            <Binding Path="SubclassIDString"/>
+                        </MultiBinding>
+                    </Setter.Value>
+                </Setter>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding SubclassIDString, Converter={StaticResource NullToBoolTrueConverter}, ConverterParameter='EmptyString'}" Value="True">
+                <Setter Property="Source">
+                    <Setter.Value>
+                        <MultiBinding Converter="{StaticResource IconIdToSourceConverter}" FallbackValue="{StaticResource IUI_GenericClassHotbarIcon}">
+                            <Binding Source="Assets/ClassIcons/hotbar/"/>
+                            <Binding Path="IDString"/>
+                        </MultiBinding>
+                    </Setter.Value>
+                </Setter>
+            </DataTrigger>
             <!--<DataTrigger Binding="{Binding IDString}" Value="Barbarian">
                 <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/ClassIcons/hotbar/barbarian.png"/>
             </DataTrigger> -->


### PR DESCRIPTION
This uses `IconIdToSourceConverter` shenanigans to try and render an icon using the `SubclassIDString`/`IDString`.

This change allows mods to add icons to the following folders, using their class ID and subclass ID, to allow the icons to render without having to submit PRs.
```
Public\Game\GUI\Assets\ClassIcons
Public\Game\GUI\Assets\ClassIcons\hotbar
```
Class/Subclass Name values should then be uniquely prefixed, to avoid conflicts (ex `LLDRAGOON_Dragoon` vs naming it just `Dragoon`).

The IconIdToSourceConverter triggers were placed first in the `Style.Triggers`, so IDs that have a hardcoded icon path will still work. Larian named their icons in all lowercase as well, which doesn't line up with their class IDs, so their paths still need to be set. This might be fixable if we had a `StringToLowerConverter`, or maybe a StringFormat (if it's possible to lowercase a string in pure xaml).

`SubclassIDString` is currently prioritized with the trigger order/logic, so it'll display that icon on your hotbar, character sheet, and in CC if a subclass is set.
Personally, I find that more desirable, as you don't see the subclass icons too often otherwise, but this could possibly be changed by just using `IDString` (`IDString` seems to also be set to the subclass ID when it goes to display subclass icons, when you pick a subclass).