### PR TITLE
Samurai icon support

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
@@ -575,7 +575,10 @@
             </DataTrigger>
             <DataTrigger Binding="{Binding SubclassIDString}" Value="UnholyDeathKnight">
                 <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ClassIcons/Icon_UnholyDeathKnight.png"/>
-			</DataTrigger>
+	    </DataTrigger>
+            <DataTrigger Binding="{Binding SubclassIDString}" Value="Samurai">
+                <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/newsamurai/ClassIcons/Icon_newsamurai.png"/>
+	    </DataTrigger>
 			<!--EDIT HERE-->
         </Style.Triggers>
 	</Style>
@@ -672,7 +675,10 @@
             </DataTrigger>
             <DataTrigger Binding="{Binding SubclassIDString}" Value="UnholyDeathKnight">
                 <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ClassIcons/hotbar/Icon_UnholyDeathKnight.png"/>
-			</DataTrigger>
+	    </DataTrigger>
+            <DataTrigger Binding="{Binding SubclassIDString}" Value="Samurai">
+                <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/newsamurai/ClassIcons/hotbar/Icon_newsamurai.png"/>
+	    </DataTrigger>
 			<!--EDIT HERE-->
         </Style.Triggers>
     </Style>


### PR DESCRIPTION
Adds the required fields for the [Samurai mod](https://www.nexusmods.com/baldursgate3/mods/2245) icon. I will add the relevant code to the mod after this is merged, to avoid conflicts.

![class_icon](https://github.com/TheRealDjmr/BG3ImprovedUI/assets/11787789/4a060ff4-6419-410d-8671-5717f44eb1ae)
