### PR TITLE
Way of Marshmerrow Monk Subclass Icon

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
@@ -534,6 +534,9 @@
 			<DataTrigger Binding="{Binding SubclassIDString}" Value="DrunkenMaster">
                 <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/drunkenmaster/ClassIcons/monk_drunkenmaster.png"/>
             </DataTrigger>
+            <DataTrigger Binding="{Binding SubclassIDString}" Value="CL_WayOfMarshmerrow">
+                <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/CommunityLibrary/ClassIcons/WayOfMarshmerrow.png"/>
+            </DataTrigger>
 			<DataTrigger Binding="{Binding SubclassIDString}" Value="Bladesinging">
                 <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/Expansion/ClassIcons/wizard_bladesinging.png"/>
             </DataTrigger>
@@ -628,6 +631,9 @@
 			<DataTrigger Binding="{Binding SubclassIDString}" Value="DrunkenMaster">
                 <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/drunkenmaster/ClassIcons/hotbar/monk_drunkenmaster.png"/>
 			</DataTrigger>
+			<DataTrigger Binding="{Binding SubclassIDString}" Value="CL_WayOfMarshmerrow">
+                <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/CommunityLibrary/ClassIcons/hotbar/WayOfMarshmerrow.png"/>
+            </DataTrigger>
 			<DataTrigger Binding="{Binding SubclassIDString}" Value="Bladesinging">
                 <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/Expansion/ClassIcons/hotbar/wizard_bladesinging.png"/>
             </DataTrigger>


### PR DESCRIPTION
- Include Refs to Regular and Simplified Subclass Icons for Way of Marshmerrow

Requires 2 mods + Script Extender to test:
- [Community Library 2.0.5.0+](https://github.com/BG3-Community-Library-Team/BG3-Community-Library/releases/tag/2.0.5.0) (Contains core pieces)
- [Way of Marshmerrow](https://github.com/NellsRelo/AGtT_Monk_WayOfMarshmerrow/releases/tag/1.0.0) (The Actual Implementation)