### PR TITLE
DemonHunter + DeathKnight Icon Support

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons.xaml
@@ -136,6 +136,8 @@
     <ImageSource x:Key="CunningDie">pack://application:,,,/GustavNoesisGUI;component/Assets/RogueRework/Shared/Resources/ico_classRes_CunningDie_d.png</ImageSource>
     <ImageSource x:Key="CunningDieUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/RogueRework/Shared/Resources/ico_classRes_CunningDie_missing.png</ImageSource>
 	<!-- EDIT HERE -->
+    <ImageSource x:Key="DemonicFury">pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/Shared/Resources/Icon_DH_DemonicFury.png</ImageSource>
+    <ImageSource x:Key="DemonicFuryUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/Shared/Resources/Icon_DH_DemonicFury_Missing.png</ImageSource>
 	
 	<!-- This is the icon that appears on the tooltip -->
 	<Style TargetType="Image" x:Key="IUI_ActionResourceTypeIdToSource" BasedOn="{StaticResource IUI_ActionResourceTypeIdToSourceDefault}">
@@ -195,6 +197,9 @@
 				<Setter Property="Source" Value="{StaticResource CunningDie}"/>
 			</DataTrigger>
 			<!-- EDIT HERE -->
+            <DataTrigger Binding="{Binding TypeId}" Value="DemonicFury">
+                <Setter Property="Source" Value="{StaticResource DemonicFury}"/>
+            </DataTrigger>
 		</Style.Triggers>
     </Style>
 	
@@ -767,6 +772,17 @@
 				</MultiDataTrigger.Setters>
 			</MultiDataTrigger>
 			<!-- EDIT HERE -->
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding TypeId}" Value="DemonicFury"/>
+                    <Condition Binding="{Binding Value}" Value="0"/>
+                    <Condition Binding="{Binding IgnoreCost}" Value="False"/>
+                </MultiDataTrigger.Conditions>
+                <MultiDataTrigger.Setters>
+                    <Setter Property="Source" Value="{StaticResource DemonicFuryUnavailable}"/>
+                </MultiDataTrigger.Setters>
+            </MultiDataTrigger>
+
         </Style.Triggers>
     </Style>
 	
@@ -1052,7 +1068,16 @@
 		<ContentControl ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
 	</ControlTemplate>
 	<!-- EDIT HERE -->
-	
+	<ControlTemplate x:Key="ActionResources.ActionGroup.DemonicFuryGroup" TargetType="ls:LSActionPoint">
+        <ControlTemplate.Resources>
+            <ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/Shared/Resources/Icon_DH_DemonicFury_Hover.png</ImageSource>
+            <ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/Shared/Resources/Icon_DH_DemonicFury.png</ImageSource>
+            <ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/Shared/Resources/Icon_DH_DemonicFury_Used.png</ImageSource>
+            <ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/Shared/Resources/Icon_DH_DemonicFury_Missing.png</ImageSource>
+        </ControlTemplate.Resources>
+        <ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
+
 	<!-- Setup default styles that are inherited before changes are applied, do not touch these -->
 	<ControlTemplate x:Key="ActionResources.ActionGroup.FallbackActionPointGroup">
         <ControlTemplate.Resources>
@@ -1578,6 +1603,21 @@
 				</MultiDataTrigger.Setters>
 			</MultiDataTrigger>
 			<!-- EDIT HERE -->
+            <DataTrigger Binding="{Binding TypeId}" Value="DemonicFury">
+                <Setter Property="ActionPointTemplate" Value="{DynamicResource ActionResources.ActionGroup.DemonicFuryGroup}"/>
+                <Setter Property="MaxGroupActionPoints" Value="1"/>
+                <Setter Property="ActionPointSize" Value="{DynamicResource ActionResources.ActionPointSize}" />
+            </DataTrigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding TypeId}" Value="DemonicFury"/>
+                    <Condition Binding="{Binding ActionResource.Value, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}" Value="True"/>
+                </MultiDataTrigger.Conditions>
+				<MultiDataTrigger.Setters>
+                    <Setter Property="Margin" Value="0,-15,0,0"/>
+                </MultiDataTrigger.Setters>
+            </MultiDataTrigger>
+                        
 		</Style.Triggers>
     </Style>
 </ResourceDictionary>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_c.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_c.xaml
@@ -276,4 +276,56 @@
 		<ContentControl ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
 	</ControlTemplate>
 	<!-- EDIT HERE -->
+    
+    <ControlTemplate x:Key="ActionResources.ActionGroup.BloodRuneGroup" TargetType="ls:LSActionPoint">
+        <ControlTemplate.Resources>
+            <ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_BloodRune_Hover.png</ImageSource>
+            <ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_BloodRune.png</ImageSource>
+            <ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_BloodRune_Used.png</ImageSource>
+            <ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_BloodRune_Missing.png</ImageSource>
+        </ControlTemplate.Resources>
+        <ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="ActionResources.ActionGroup.FrostRuneGroup" TargetType="ls:LSActionPoint">
+        <ControlTemplate.Resources>
+            <ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_FrostRune_Hover.png</ImageSource>
+            <ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_FrostRune.png</ImageSource>
+            <ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_FrostRune_Used.png</ImageSource>
+            <ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_FrostRune_Missing.png</ImageSource>
+        </ControlTemplate.Resources>
+        <ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="ActionResources.ActionGroup.UnholyRuneGroup" TargetType="ls:LSActionPoint">
+        <ControlTemplate.Resources>
+            <ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_UnholyRune_Hover.png</ImageSource>
+            <ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_UnholyRune.png</ImageSource>
+            <ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_UnholyRune_Used.png</ImageSource>
+            <ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_UnholyRune_Missing.png</ImageSource>
+        </ControlTemplate.Resources>
+        <ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="ActionResources.ActionGroup.RunicPowerGroup" TargetType="ls:LSActionPoint">
+        <ControlTemplate.Resources>
+            <ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_RunicPower_Hover.png</ImageSource>
+            <ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_RunicPower.png</ImageSource>
+            <ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_RunicPower_Used.png</ImageSource>
+            <ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_RunicPower_Missing.png</ImageSource>
+        </ControlTemplate.Resources>
+        <ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+    </ControlTemplate>
+
+    <ControlTemplate x:Key="ActionResources.ActionGroup.DemonicFuryGroup" TargetType="ls:LSActionPoint">
+        <ControlTemplate.Resources>
+            <ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/ActionResources_c/Icons/Icon_DH_DemonicFury_Hover.png</ImageSource>
+            <ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/ActionResources_c/Icons/Icon_DH_DemonicFury.png</ImageSource>
+            <ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/ActionResources_c/Icons/Icon_DH_DemonicFury_Used.png</ImageSource>
+            <ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/ActionResources_c/Icons/Icon_DH_DemonicFury_Missing.png</ImageSource>
+        </ControlTemplate.Resources>
+        <ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+    </ControlTemplate>
+
+
 </ResourceDictionary>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
@@ -385,7 +385,82 @@
 				<Setter TargetName="LevelImage" Property="Stretch" Value="Fill"/>
 			</DataTrigger>
 			<!-- EDIT HERE -->
-			
+            <DataTrigger Binding="{Binding ActionResource.TypeId}" Value="BloodRune">
+				<Setter TargetName="ResourcePoints" Property="Visibility" Value="Collapsed"/>
+				<Setter TargetName="ResourcePoints" Property="MaxActionPoints" Value="1"/>
+				<Setter TargetName="ResourceName" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceAmount" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourcePointsStack" Property="Margin" Value="22,0,22,0"/>
+                <Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_BloodRune.png"/>
+				<Setter TargetName="LevelImage" Property="Margin" Value="-10,0,-10,0"/>
+				<Setter TargetName="LevelImage" Property="Height" Value="50"/>
+				<Setter TargetName="LevelImage" Property="Width" Value="50"/>
+				<Setter TargetName="LevelImage" Property="Stretch" Value="Fill"/>                
+				<Setter TargetName="ActionResourceBackground" Property="Fill" Value="#cc0000"/>
+                <Setter TargetName="ActionResourceBackgroundStroke" Property="Stroke" Value="#cc0000"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding ActionResource.TypeId}" Value="FrostRune">
+				<Setter TargetName="ResourcePoints" Property="Visibility" Value="Collapsed"/>
+				<Setter TargetName="ResourcePoints" Property="MaxActionPoints" Value="1"/>
+				<Setter TargetName="ResourceName" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceAmount" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="ResourcePointsStack" Property="Margin" Value="22,0,22,0"/>
+                <Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_FrostRune.png"/>
+				<Setter TargetName="LevelImage" Property="Margin" Value="-10,0,-10,0"/>
+				<Setter TargetName="LevelImage" Property="Height" Value="50"/>
+				<Setter TargetName="LevelImage" Property="Width" Value="50"/>
+				<Setter TargetName="LevelImage" Property="Stretch" Value="Fill"/>  
+				<Setter TargetName="ActionResourceBackground" Property="Fill" Value="#3abad6"/>
+                <Setter TargetName="ActionResourceBackgroundStroke" Property="Stroke" Value="#3abad6"/>
+            </DataTrigger>
+            <DataTrigger Binding="{Binding ActionResource.TypeId}" Value="UnholyRune">
+				<Setter TargetName="ResourcePoints" Property="Visibility" Value="Collapsed"/>
+				<Setter TargetName="ResourcePoints" Property="MaxActionPoints" Value="1"/>
+				<Setter TargetName="ResourceName" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceAmount" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="ResourcePointsStack" Property="Margin" Value="22,0,22,0"/>
+                <Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_UnholyRune.png"/>
+				<Setter TargetName="LevelImage" Property="Margin" Value="-10,0,-10,0"/>
+				<Setter TargetName="LevelImage" Property="Height" Value="50"/>
+				<Setter TargetName="LevelImage" Property="Width" Value="50"/>
+				<Setter TargetName="LevelImage" Property="Stretch" Value="Fill"/>  
+				<Setter TargetName="ActionResourceBackground" Property="Fill" Value="#93c47d"/>
+                <Setter TargetName="ActionResourceBackgroundStroke" Property="Stroke" Value="#93c47d"/>
+            </DataTrigger>
+			<DataTrigger Binding="{Binding ActionResource.TypeId}" Value="RunicPower">
+				<Setter TargetName="ResourcePoints" Property="Visibility" Value="Collapsed"/>
+				<Setter TargetName="ResourcePoints" Property="MaxActionPoints" Value="1"/>
+				<Setter TargetName="ResourceName" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceAmount" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="ResourcePointsStack" Property="Margin" Value="22,0,22,0"/>
+                <Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_RunicPower.png"/>
+				<Setter TargetName="LevelImage" Property="Margin" Value="-10,0,-10,0"/>
+				<Setter TargetName="LevelImage" Property="Height" Value="50"/>
+				<Setter TargetName="LevelImage" Property="Width" Value="50"/>
+				<Setter TargetName="LevelImage" Property="Stretch" Value="Fill"/>
+                <Setter TargetName="ActionResourceBackground" Property="Fill" Value="#26a2f4"/>
+                <Setter TargetName="ActionResourceBackgroundStroke" Property="Stroke" Value="#26a2f4"/>
+            </DataTrigger>
+			<DataTrigger Binding="{Binding ActionResource.TypeId}" Value="DemonicFury">
+				<Setter TargetName="ResourcePoints" Property="Visibility" Value="Collapsed"/>
+				<Setter TargetName="ResourcePoints" Property="MaxActionPoints" Value="1"/>
+				<Setter TargetName="ResourceName" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceAmount" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="ResourcePointsStack" Property="Margin" Value="22,0,22,0"/>
+                <Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/ActionResources_c/Icons/Icon_DH_DemonicFury.png"/>
+				<Setter TargetName="LevelImage" Property="Margin" Value="-10,0,-10,0"/>
+				<Setter TargetName="LevelImage" Property="Height" Value="50"/>
+				<Setter TargetName="LevelImage" Property="Width" Value="50"/>
+				<Setter TargetName="LevelImage" Property="Stretch" Value="Fill"/>
+				<Setter TargetName="ActionResourceBackground" Property="Fill" Value="#9933FF"/>
+				<Setter TargetName="ActionResourceBackgroundStroke" Property="Stroke" Value="#9933FF"/>
+            </DataTrigger>	
+
 			<!-- Please leave the below alone -->
 			<DataTrigger Binding="{Binding ActionResource.Level}" Value="1">
 				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
@@ -732,7 +807,46 @@
 				<Setter TargetName="ResourceImage" Property="Width" Value="50"/>
 			</DataTrigger>
 			<!-- EDIT HERE -->
-
+			<DataTrigger Binding="{Binding TypeId}" Value="BloodRune">
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_BloodRune.png"/>
+                <Setter TargetName="ResourceImage" Property="Visibility" Value="Collapsed"/>
+                <Setter TargetName="ResourceName" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceValue" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceValue" Property="ls:TextBlockFormatter.SourceText" Value="{Binding MaxValue}"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding TypeId}" Value="FrostRune">
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_FrostRune.png"/>
+                <Setter TargetName="ResourceImage" Property="Visibility" Value="Collapsed"/>
+                <Setter TargetName="ResourceName" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceValue" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceValue" Property="ls:TextBlockFormatter.SourceText" Value="{Binding MaxValue}"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding TypeId}" Value="UnholyRune">
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_UnholyRune.png"/>
+                <Setter TargetName="ResourceImage" Property="Visibility" Value="Collapsed"/>
+                <Setter TargetName="ResourceName" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceValue" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceValue" Property="ls:TextBlockFormatter.SourceText" Value="{Binding MaxValue}"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding TypeId}" Value="RunicPower">
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ActionResources_c/Icons/Icon_DK_RunicPower.png"/>
+                <Setter TargetName="ResourceImage" Property="Visibility" Value="Collapsed"/>
+                <Setter TargetName="ResourceName" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceValue" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceValue" Property="ls:TextBlockFormatter.SourceText" Value="{Binding MaxValue}"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding TypeId}" Value="DemonicFury">
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/ActionResources_c/Icons/Icon_DH_DemonicFury.png"/>
+                <Setter TargetName="ResourceImage" Property="Visibility" Value="Collapsed"/>
+                <Setter TargetName="ResourceName" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceValue" Property="Visibility" Value="Visible"/>
+                <Setter TargetName="ResourceValue" Property="ls:TextBlockFormatter.SourceText" Value="{Binding MaxValue}"/>
+			</DataTrigger>			
 
             <DataTrigger Binding="{Binding Level}" Value="1">
                 <Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
@@ -160,6 +160,10 @@
 				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ClassIcons/Icon_WoWDeathKnightClass.png"/>
 			</DataTrigger>
 			<!--EDIT HERE-->
+            <DataTrigger Binding="{Binding IDString}" Value="WoWDemonHunter">
+                <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/ClassIcons/Icon_WoWDemonHunterClass.png"/>
+            </DataTrigger>
+
 		</Style.Triggers>
 	</Style>
 	
@@ -200,6 +204,9 @@
 				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ClassIcons/hotbar/Icon_WoWDeathKnightClass.png"/>
 			</DataTrigger>
 			<!--EDIT HERE-->
+            <DataTrigger Binding="{Binding IDString}" Value="WoWDemonHunter">
+                <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/ClassIcons/hotbar/Icon_WoWDemonHunterClass.png"/>
+            </DataTrigger>
         </Style.Triggers>
     </Style>
 	
@@ -652,6 +659,13 @@
 				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ClassIcons/Icon_UnholyDeathKnight.png"/>
 			</DataTrigger>
 			<!--EDIT HERE-->
+            <DataTrigger Binding="{Binding SubclassIDString}" Value="HavocDemonHunter">
+                <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/ClassIcons/Icon_HavocDemonHunter.png"/>
+			</DataTrigger>
+            <DataTrigger Binding="{Binding SubclassIDString}" Value="VengeanceDemonHunter">
+                <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/ClassIcons/Icon_VengeanceDemonHunter.png"/>
+			</DataTrigger>
+
         </Style.Triggers>
 	</Style>
 	
@@ -791,6 +805,13 @@
 				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDeathKnightClass/ClassIcons/hotbar/Icon_UnholyDeathKnight.png"/>
 			</DataTrigger>
 			<!--EDIT HERE-->
+            <DataTrigger Binding="{Binding SubclassIDString}" Value="HavocDemonHunter">
+                <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/ClassIcons/hotbar/Icon_HavocDemonHunter.png"/>
+			</DataTrigger>
+            <DataTrigger Binding="{Binding SubclassIDString}" Value="VengeanceDemonHunter">
+                <Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/WoWDemonHunterClass/ClassIcons/hotbar/Icon_VengeanceDemonHunter.png"/>
+			</DataTrigger>
+            
         </Style.Triggers>
     </Style>
 </ResourceDictionary>


### PR DESCRIPTION
Hi Djmr,

Thanks again for maintaining this repository.

For this pull request I've made the following updates for my [Death Knight Class](https://www.nexusmods.com/baldursgate3/mods/1725/?tab=description) and [Demon Hunter Class](https://www.nexusmods.com/baldursgate3/mods/3165):

1. _IUI_ClassIcons.xaml_
```
- Added Class Icons for the Demon Hunter Class 
```
2. _IUI_ActionResourceIcons.xaml_
```
- Added Action Resource Icons for the Demon Hunter Class
```
3. _IUI_ActionResourceIcons_c.xaml_
```
- Added controller UI icons for Death Knight action resources (Blood Rune/Frost Rune/Unholy Rune/Runic Power)
- Added controller UI icons for Demon Hunter action resources (Demonic Fury)
```
4. _IUI_ActionResourceTemplates_c.xaml_
```
- Defined controller hotbar & cost preview icon styles for Death Knight action resources (Blood Rune/Frost Rune/Unholy Rune/Runic Power)
- Defined controller hotbar & cost preview icon styles for Demon Hunter action resources (Demonic Fury)
```
All changes have been tested and are working on my end. In case you need to test the Demon Hunter icons, the Demonic Fury works in the same way as Death Knight's Runic Power so it should be working if Runic Power is working on your end.

Thanks again for all your help and support!

Cheers,
VivaSortiara