### PR TITLE
Witch Elf Icon Support IUI_RaceIcons.xaml

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/IUI_RaceIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_RaceIcons.xaml
@@ -131,6 +131,13 @@
 					</Setter.Value>
 				</Setter>
 			</DataTrigger>
+			<DataTrigger Binding="{Binding Guid}" Value="b3eb9cb4-23bf-481f-8f05-981b0128d7d4">
+				<Setter Property="OpacityMask">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/WitchElf/CC/icons_races/Elf_WitchElf.png"/>
+					</Setter.Value>
+				</Setter>
+			</DataTrigger>
 			<!--EDIT HERE-->
 		</Style.Triggers>
 	</Style>


### PR DESCRIPTION
Hello! <3 
This is a request to include my subrace's icon. This mod adds brand new subrace to Elves called Witch Elf, which is heavily inspired by HOMM5, WoW and Total War: Warhammer 2. It has a custom cantrip with edited VFX and two racial passives. It is 97% done, just need to include other spell/passive icons and clean up notes before release! My discord is: @covenelf in case you need my mod's files.