### PR TITLE
Subclass Icons for "The Raven Queen Patron" mod

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
@@ -675,6 +675,9 @@
 			<DataTrigger Binding="{Binding SubclassIDString}" Value="Perun">
 				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/Wielder/ClassIcons/Perun.png"/>
 			</DataTrigger>
+			<DataTrigger Binding="{Binding SubclassIDString}" Value="TheRavenQueen">
+				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/TheRavenQueen/ClassIcons/warlock_ravenqueen.png"/>
+			</DataTrigger>
 			<!--EDIT HERE-->
 		</Style.Triggers>
 	</Style>
@@ -825,6 +828,9 @@
 			</DataTrigger>
 			<DataTrigger Binding="{Binding SubclassIDString}" Value="Perun">
 				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/Wielder/ClassIcons/hotbar/Perun_hotbar.png"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding SubclassIDString}" Value="TheRavenQueen">
+				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/TheRavenQueen/ClassIcons/hotbar/warlock_ravenqueen_simplified.png"/>
 			</DataTrigger>
 			<!--EDIT HERE-->
 		</Style.Triggers>


### PR DESCRIPTION
[Nexus link to the mod](https://www.nexusmods.com/baldursgate3/mods/1895)

Icons with correct pathing included since Sept 12, mod version 1.0.2 . 

(I'm making this PR instead of the mod author because, erm, I offered to do so for the author back in September, but he said he wanted to wait til the then-issues IUI was having were resolved... which they very shortly were... and I haven't seen activity from the mod author since Sept 19... and the users of the mod have been asking about the icon... and the icon (that I made) _is there_ in the mod files... it's just not being "used".... ANYWAY I just have a vested interest, fdjskfdjslk)

![20230912182808_1(1)](https://github.com/TheRealDjmr/BG3ImprovedUI/assets/83232936/ebf3f7a8-269d-43cd-b764-72e19ec15ba9)
