### PR TITLE
Update IUI_ClassIcons.xaml

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
@@ -165,6 +165,9 @@
 			<DataTrigger Binding="{Binding IDString}" Value="Wielder">
 				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/Wielder/ClassIcons/Wielder.png"/>
 			</DataTrigger>
+			<DataTrigger Binding="{Binding IDString}" Value="Vanguard">
+				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/VanguardClass/ClassIcons/Vanguard.png"/>
+			</DataTrigger>
 			<!--EDIT HERE-->
 		</Style.Triggers>
 	</Style>
@@ -210,6 +213,9 @@
 			</DataTrigger>
 			<DataTrigger Binding="{Binding IDString}" Value="Wielder">
 				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/Wielder/ClassIcons/hotbar/Wielder_hotbar.png"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding IDString}" Value="Vanguard">
+				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/VanguardClass/ClassIcons/hotbar/Vanguard_hotbar.png"/>
 			</DataTrigger>
 			<!--EDIT HERE-->
 		</Style.Triggers>
@@ -678,6 +684,9 @@
 			<DataTrigger Binding="{Binding SubclassIDString}" Value="TheRavenQueen">
 				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/TheRavenQueen/ClassIcons/warlock_ravenqueen.png"/>
 			</DataTrigger>
+			<DataTrigger Binding="{Binding SubclassIDString}" Value="Elementalist">
+				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/VanguardClass/ClassIcons/Elementalist.png"/>
+			</DataTrigger>
 			<!--EDIT HERE-->
 		</Style.Triggers>
 	</Style>
@@ -831,6 +840,9 @@
 			</DataTrigger>
 			<DataTrigger Binding="{Binding SubclassIDString}" Value="TheRavenQueen">
 				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/TheRavenQueen/ClassIcons/hotbar/warlock_ravenqueen_simplified.png"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding SubclassIDString}" Value="Elementalist">
+				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/VanguardClass/ClassIcons/hotbar/Elementalist_hotbar.png"/>
 			</DataTrigger>
 			<!--EDIT HERE-->
 		</Style.Triggers>


### PR DESCRIPTION
Added lines for Vanguard Class and its associated Elementalist subclass.

Class can be found on NexusMods here: https://www.nexusmods.com/baldursgate3/mods/3686?tab=description

The actual icon art data doesn't exist in the version available for download and is only on my local machine. 

I actually would have preferred to be able to test everything locally before creating a pull request, but I couldn't get it to work even when trying to pack my own local version of ImprovedUIAssets - no art would show up, even for other classes like Artificer in that case. So I'm assuming it's only possible by doing it this way first.

