### PR TITLE
Fix duplicated spell/passive selection tabs in CC

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/CCLib_k.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/CCLib_k.xaml
@@ -1253,6 +1253,7 @@
             <!-- MOD START - Spell subtabs for racial spells on LevelUp -->
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding DataContext.IsLevelUp, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, FallbackValue=False}" Value="True"/>
                     <Condition Binding="{Binding Path=Tag, RelativeSource={RelativeSource Mode=Self}}" Value="race"/>
                     <Condition Binding="{Binding RaceProgressionDetails.SpellSelectors.Count, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True"/>
                 </MultiDataTrigger.Conditions>
@@ -1318,6 +1319,7 @@
             <!-- MOD NOTE - Racial passive selection in LevelUp -->
             <MultiDataTrigger>
 				<MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding DataContext.IsLevelUp, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, FallbackValue=False}" Value="True"/>
 					<Condition Binding="{Binding Path=Tag, RelativeSource={RelativeSource Mode=Self}}" Value="race"/>
 					<Condition Binding="{Binding Path=RaceProgressionDetails.NotSubPassiveSelectors.Count, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True"/>
 				</MultiDataTrigger.Conditions>
@@ -1326,6 +1328,7 @@
 			</MultiDataTrigger>
 			<MultiDataTrigger>
 				<MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding DataContext.IsLevelUp, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, FallbackValue=False}" Value="True"/>
 					<Condition Binding="{Binding Path=Tag, RelativeSource={RelativeSource Mode=Self}}" Value="race"/>
 					<Condition Binding="{Binding Path=RaceProgressionDetails.SubPassiveSelectors.Count, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True"/>
 				</MultiDataTrigger.Conditions>

--- a/ImprovedUI/Public/Game/GUI/Library/CCLib_k.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/CCLib_k.xaml
@@ -1319,7 +1319,7 @@
             <!-- MOD NOTE - Racial passive selection in LevelUp -->
             <MultiDataTrigger>
 				<MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding DataContext.IsLevelUp, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, FallbackValue=False}" Value="True"/>
+					<Condition Binding="{Binding DataContext.IsLevelUp, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, FallbackValue=False}" Value="True"/>
 					<Condition Binding="{Binding Path=Tag, RelativeSource={RelativeSource Mode=Self}}" Value="race"/>
 					<Condition Binding="{Binding Path=RaceProgressionDetails.NotSubPassiveSelectors.Count, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True"/>
 				</MultiDataTrigger.Conditions>
@@ -1328,7 +1328,7 @@
 			</MultiDataTrigger>
 			<MultiDataTrigger>
 				<MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding DataContext.IsLevelUp, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, FallbackValue=False}" Value="True"/>
+					<Condition Binding="{Binding DataContext.IsLevelUp, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, FallbackValue=False}" Value="True"/>
 					<Condition Binding="{Binding Path=Tag, RelativeSource={RelativeSource Mode=Self}}" Value="race"/>
 					<Condition Binding="{Binding Path=RaceProgressionDetails.SubPassiveSelectors.Count, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True"/>
 				</MultiDataTrigger.Conditions>

--- a/ImprovedUI/Public/Game/GUI/Library/CCLib_k.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/CCLib_k.xaml
@@ -1300,42 +1300,42 @@
                 <Setter TargetName="subTabsPassivesList" Property="ItemsSource" Value="{Binding ClassProgressionDetails.NotSubPassiveSelectors}"/>
             </MultiDataTrigger>
             <!-- MOD START - Racial passive selection in CC -->
-			<MultiDataTrigger>
-				<MultiDataTrigger.Conditions>
-					<Condition Binding="{Binding Path=Tag, RelativeSource={RelativeSource Mode=Self}}" Value="race"/>
-					<Condition Binding="{Binding Path=DataContext.RacePassives.Count, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True"/>
-				</MultiDataTrigger.Conditions>
-				<Setter TargetName="subTabs" Property="Visibility" Value="Visible"/>
-				<Setter TargetName="subTabsPassivesList" Property="ItemsSource" Value="{Binding RaceProgressionDetails.NotSubPassiveSelectors}"/>
-			</MultiDataTrigger>
-			<MultiDataTrigger>
-				<MultiDataTrigger.Conditions>
-					<Condition Binding="{Binding Path=Tag, RelativeSource={RelativeSource Mode=Self}}" Value="subrace"/>
-					<Condition Binding="{Binding Path=DataContext.SubRacePassives.Count, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True"/>
-				</MultiDataTrigger.Conditions>
-				<Setter TargetName="subTabs" Property="Visibility" Value="Visible"/>
-				<Setter TargetName="subTabsPassivesList" Property="ItemsSource" Value="{Binding RaceProgressionDetails.SubPassiveSelectors}"/>
-			</MultiDataTrigger>
+		<MultiDataTrigger>
+			<MultiDataTrigger.Conditions>
+				<Condition Binding="{Binding Path=Tag, RelativeSource={RelativeSource Mode=Self}}" Value="race"/>
+				<Condition Binding="{Binding Path=DataContext.RacePassives.Count, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True"/>
+			</MultiDataTrigger.Conditions>
+			<Setter TargetName="subTabs" Property="Visibility" Value="Visible"/>
+			<Setter TargetName="subTabsPassivesList" Property="ItemsSource" Value="{Binding RaceProgressionDetails.NotSubPassiveSelectors}"/>
+		</MultiDataTrigger>
+		<MultiDataTrigger>
+			<MultiDataTrigger.Conditions>
+				<Condition Binding="{Binding Path=Tag, RelativeSource={RelativeSource Mode=Self}}" Value="subrace"/>
+				<Condition Binding="{Binding Path=DataContext.SubRacePassives.Count, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True"/>
+			</MultiDataTrigger.Conditions>
+			<Setter TargetName="subTabs" Property="Visibility" Value="Visible"/>
+			<Setter TargetName="subTabsPassivesList" Property="ItemsSource" Value="{Binding RaceProgressionDetails.SubPassiveSelectors}"/>
+		</MultiDataTrigger>
             <!-- MOD NOTE - Racial passive selection in LevelUp -->
-            <MultiDataTrigger>
-				<MultiDataTrigger.Conditions>
-					<Condition Binding="{Binding DataContext.IsLevelUp, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, FallbackValue=False}" Value="True"/>
-					<Condition Binding="{Binding Path=Tag, RelativeSource={RelativeSource Mode=Self}}" Value="race"/>
-					<Condition Binding="{Binding Path=RaceProgressionDetails.NotSubPassiveSelectors.Count, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True"/>
-				</MultiDataTrigger.Conditions>
-				<Setter TargetName="subTabs" Property="Visibility" Value="Visible"/>
-				<Setter TargetName="subTabsPassivesList" Property="ItemsSource" Value="{Binding RaceProgressionDetails.NotSubPassiveSelectors}"/>
-			</MultiDataTrigger>
-			<MultiDataTrigger>
-				<MultiDataTrigger.Conditions>
-					<Condition Binding="{Binding DataContext.IsLevelUp, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, FallbackValue=False}" Value="True"/>
-					<Condition Binding="{Binding Path=Tag, RelativeSource={RelativeSource Mode=Self}}" Value="race"/>
-					<Condition Binding="{Binding Path=RaceProgressionDetails.SubPassiveSelectors.Count, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True"/>
-				</MultiDataTrigger.Conditions>
-				<Setter TargetName="subTabs" Property="Visibility" Value="Visible"/>
-				<Setter TargetName="subTabsPassivesList" Property="ItemsSource" Value="{Binding RaceProgressionDetails.SubPassiveSelectors}"/>
-			</MultiDataTrigger>
-			<!-- MOD END -->
+		<MultiDataTrigger>
+			<MultiDataTrigger.Conditions>
+				<Condition Binding="{Binding DataContext.IsLevelUp, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, FallbackValue=False}" Value="True"/>
+				<Condition Binding="{Binding Path=Tag, RelativeSource={RelativeSource Mode=Self}}" Value="race"/>
+				<Condition Binding="{Binding Path=RaceProgressionDetails.NotSubPassiveSelectors.Count, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True"/>
+			</MultiDataTrigger.Conditions>
+			<Setter TargetName="subTabs" Property="Visibility" Value="Visible"/>
+			<Setter TargetName="subTabsPassivesList" Property="ItemsSource" Value="{Binding RaceProgressionDetails.NotSubPassiveSelectors}"/>
+		</MultiDataTrigger>
+		<MultiDataTrigger>
+			<MultiDataTrigger.Conditions>
+				<Condition Binding="{Binding DataContext.IsLevelUp, RelativeSource={RelativeSource AncestorType={x:Type ls:UIWidget}}, FallbackValue=False}" Value="True"/>
+				<Condition Binding="{Binding Path=Tag, RelativeSource={RelativeSource Mode=Self}}" Value="race"/>
+				<Condition Binding="{Binding Path=RaceProgressionDetails.SubPassiveSelectors.Count, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True"/>
+			</MultiDataTrigger.Conditions>
+			<Setter TargetName="subTabs" Property="Visibility" Value="Visible"/>
+			<Setter TargetName="subTabsPassivesList" Property="ItemsSource" Value="{Binding RaceProgressionDetails.SubPassiveSelectors}"/>
+		</MultiDataTrigger>
+		<!-- MOD END -->
 
             <!-- Equipment subtabs -->
             <MultiDataTrigger>


### PR DESCRIPTION
Adds `IsLevelUp` condition check for levelup spell/passive selection subtab triggers.