### PR TITLE
2 new resources for 2 separate mods

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons.xaml
@@ -181,6 +181,10 @@
 	<ImageSource x:Key="GlamourUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/Briarguard/Shared/Resources/ico_classRes_Glamour_missing.png</ImageSource>
 	<ImageSource x:Key="GZI_Psionic_Focus" >pack://application:,,,/GustavNoesisGUI;component/Assets/FollowersOfZerthimon/Shared/Resources/ico_classRes_GZI_Psionic_Focus_d.png</ImageSource>
 	<ImageSource x:Key="GZI_Psionic_FocusUnavailable" >pack://application:,,,/GustavNoesisGUI;component/Assets/FollowersOfZerthimon/Shared/Resources/ico_classRes_GZI_Psionic_Focus_missing.png</ImageSource>	
+	<ImageSource x:Key="SiaelIPORes">pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/c_ico_Ress_Siael_IPO_Resource_d.png</ImageSource>
+	<ImageSource x:Key="SiaelIPOResUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/c_ico_Ress_Siael_IPO_Resource_missing.png</ImageSource>
+	<ImageSource x:Key="OffHandExtraAttackCharge">pack://application:,,,/GustavNoesisGUI;component/Assets/OffHandExtraAttack/Shared/Resources/ico_extraAtt_d.png</ImageSource>
+	<ImageSource x:Key="OffHandExtraAttackChargeUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/OffHandExtraAttack/Shared/Resources/ico_extraAtt_missing.png</ImageSource>	
 	<!-- EDIT HERE -->
 
 	<!-- This is the icon that appears on the tooltip -->
@@ -308,7 +312,13 @@
 			</DataTrigger>
 			<DataTrigger Binding="{Binding TypeId}" Value="GZI_Psionic_Focus">
 				<Setter Property="Source" Value="{StaticResource GZI_Psionic_Focus}"/>
-			</DataTrigger>			
+			</DataTrigger>	
+			<DataTrigger Binding="{Binding TypeId}" Value="SiaelIPORes">
+				<Setter Property="Source" Value="{StaticResource SiaelIPORes}"/>
+			</DataTrigger>		
+			<DataTrigger Binding="{Binding TypeId}" Value="OffHandExtraAttackCharge">
+				<Setter Property="Source" Value="{StaticResource OffHandExtraAttackCharge}"/>
+			</DataTrigger>	
 			<!-- EDIT HERE -->
 		</Style.Triggers>
 	</Style>
@@ -1110,7 +1120,27 @@
 				<MultiDataTrigger.Setters>
 					<Setter Property="Source" Value="{StaticResource GZI_Psionic_FocusUnavailable}"/>
 				</MultiDataTrigger.Setters>
-			</MultiDataTrigger>			
+			</MultiDataTrigger>
+			<MultiDataTrigger>
+			    <MultiDataTrigger.Conditions>
+			        <Condition Binding="{Binding TypeId}" Value="SiaelIPORes"/>
+			        <Condition Binding="{Binding Value}" Value="0"/>
+			        <Condition Binding="{Binding IgnoreCost}" Value="False"/>
+			    </MultiDataTrigger.Conditions>
+			    <MultiDataTrigger.Setters>
+			        <Setter Property="Source" Value="{StaticResource SiaelIPOResUnavailable}"/>
+			    </MultiDataTrigger.Setters>
+			</MultiDataTrigger>	
+			<MultiDataTrigger>
+			    <MultiDataTrigger.Conditions>
+			        <Condition Binding="{Binding TypeId}" Value="OffHandExtraAttackCharge"/>
+			        <Condition Binding="{Binding Value}" Value="0"/>
+			        <Condition Binding="{Binding IgnoreCost}" Value="False"/>
+			    </MultiDataTrigger.Conditions>
+			    <MultiDataTrigger.Setters>
+			        <Setter Property="Source" Value="{StaticResource OffHandExtraAttackChargeUnavailable}"/>
+			    </MultiDataTrigger.Setters>
+			</MultiDataTrigger>	
 			<!-- EDIT HERE -->
 		</Style.Triggers>
 	</Style>
@@ -1627,6 +1657,26 @@
 		</ControlTemplate.Resources>
 		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
 	</ControlTemplate>	
+
+	<ControlTemplate x:Key="ActionResources.ActionGroup.SiaelIPOResGroup" TargetType="ls:LSActionPoint">
+	    <ControlTemplate.Resources>
+	        <ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/c_ico_Ress_Siael_IPO_Resource_h.png</ImageSource>
+	        <ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/c_ico_Ress_Siael_IPO_Resource_d.png</ImageSource>
+	        <ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/c_ico_Ress_Siael_IPO_Resource_spent.png</ImageSource>
+	        <ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/c_ico_Ress_Siael_IPO_Resource_missing.png</ImageSource>
+	    </ControlTemplate.Resources>
+	    <ContentControl ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
+
+	<ControlTemplate x:Key="ActionResources.ActionGroup.OffHandExtraAttackChargeGroup" TargetType="ls:LSActionPoint">
+	    <ControlTemplate.Resources>
+	        <ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/OffHandExtraAttack/Shared/Resources/ico_extraAtt_h.png</ImageSource>
+	        <ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/OffHandExtraAttack/Shared/Resources/ico_extraAtt_d.png</ImageSource>
+	        <ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/OffHandExtraAttack/Shared/Resources/ico_extraAtt_spent.png</ImageSource>
+	        <ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/OffHandExtraAttack/Shared/Resources/ico_extraAtt_missing.png</ImageSource>
+	    </ControlTemplate.Resources>
+	    <ContentControl ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
 	<!-- EDIT HERE -->
 
 	<!-- Setup default styles that are inherited before changes are applied, do not touch these -->
@@ -2460,7 +2510,35 @@
 				<MultiDataTrigger.Setters>
 					<Setter Property="Margin" Value="0,-15,0,0"/>
 				</MultiDataTrigger.Setters>
-			</MultiDataTrigger>			
+			</MultiDataTrigger>	
+
+			<DataTrigger Binding="{Binding TypeId}" Value="SiaelIPORes">
+			    <Setter Property="ActionPointTemplate" Value="{DynamicResource ActionResources.ActionGroup.SiaelIPOResGroup}"/>
+			    <Setter Property="ActionPointSize" Value="{DynamicResource ActionResources.ActionPointSize}" />
+			</DataTrigger>
+			<MultiDataTrigger>
+			    <MultiDataTrigger.Conditions>
+			        <Condition Binding="{Binding TypeId}" Value="SiaelIPORes"/>
+			        <Condition Binding="{Binding Value, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}" Value="True"/>
+			    </MultiDataTrigger.Conditions>
+			    <MultiDataTrigger.Setters>
+			        <Setter Property="Margin" Value="0,-15,0,0"/>
+			    </MultiDataTrigger.Setters>
+			</MultiDataTrigger>	
+
+			<DataTrigger Binding="{Binding TypeId}" Value="OffHandExtraAttackCharge">
+			    <Setter Property="ActionPointTemplate" Value="{DynamicResource ActionResources.ActionGroup.OffHandExtraAttackChargeGroup}"/>
+			    <Setter Property="ActionPointSize" Value="{DynamicResource ActionResources.ActionPointSize}" />
+			</DataTrigger>
+			<MultiDataTrigger>
+			    <MultiDataTrigger.Conditions>
+			        <Condition Binding="{Binding TypeId}" Value="OffHandExtraAttackCharge"/>
+			        <Condition Binding="{Binding Value, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}" Value="True"/>
+			    </MultiDataTrigger.Conditions>
+			    <MultiDataTrigger.Setters>
+			        <Setter Property="Margin" Value="0,-15,0,0"/>
+			    </MultiDataTrigger.Setters>
+			</MultiDataTrigger>	
 			<!-- EDIT HERE --> 
 		</Style.Triggers>
 	</Style>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons.xaml
@@ -181,8 +181,8 @@
 	<ImageSource x:Key="GlamourUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/Briarguard/Shared/Resources/ico_classRes_Glamour_missing.png</ImageSource>
 	<ImageSource x:Key="GZI_Psionic_Focus" >pack://application:,,,/GustavNoesisGUI;component/Assets/FollowersOfZerthimon/Shared/Resources/ico_classRes_GZI_Psionic_Focus_d.png</ImageSource>
 	<ImageSource x:Key="GZI_Psionic_FocusUnavailable" >pack://application:,,,/GustavNoesisGUI;component/Assets/FollowersOfZerthimon/Shared/Resources/ico_classRes_GZI_Psionic_Focus_missing.png</ImageSource>	
-	<ImageSource x:Key="SiaelIPORes">pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/c_ico_Ress_Siael_IPO_Resource_d.png</ImageSource>
-	<ImageSource x:Key="SiaelIPOResUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/c_ico_Ress_Siael_IPO_Resource_missing.png</ImageSource>
+	<ImageSource x:Key="SiaelIPORes">pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_Resource_d.png</ImageSource>
+	<ImageSource x:Key="SiaelIPOResUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_Resource_missing.png</ImageSource>
 	<ImageSource x:Key="OffHandExtraAttackCharge">pack://application:,,,/GustavNoesisGUI;component/Assets/OffHandExtraAttack/Shared/Resources/ico_extraAtt_d.png</ImageSource>
 	<ImageSource x:Key="OffHandExtraAttackChargeUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/OffHandExtraAttack/Shared/Resources/ico_extraAtt_missing.png</ImageSource>	
 	<!-- EDIT HERE -->
@@ -1660,9 +1660,9 @@
 
 	<ControlTemplate x:Key="ActionResources.ActionGroup.SiaelIPOResGroup" TargetType="ls:LSActionPoint">
 	    <ControlTemplate.Resources>
-	        <ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/c_ico_Ress_Siael_IPO_Resource_h.png</ImageSource>
-	        <ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/c_ico_Ress_Siael_IPO_Resource_d.png</ImageSource>
-	        <ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/c_ico_Ress_Siael_IPO_Resource_spent.png</ImageSource>
+	        <ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_Resource_h.png</ImageSource>
+	        <ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_Resource_d.png</ImageSource>
+	        <ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_Resource_spent.png</ImageSource>
 	        <ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/c_ico_Ress_Siael_IPO_Resource_missing.png</ImageSource>
 	    </ControlTemplate.Resources>
 	    <ContentControl ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons.xaml
@@ -181,8 +181,8 @@
 	<ImageSource x:Key="GlamourUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/Briarguard/Shared/Resources/ico_classRes_Glamour_missing.png</ImageSource>
 	<ImageSource x:Key="GZI_Psionic_Focus" >pack://application:,,,/GustavNoesisGUI;component/Assets/FollowersOfZerthimon/Shared/Resources/ico_classRes_GZI_Psionic_Focus_d.png</ImageSource>
 	<ImageSource x:Key="GZI_Psionic_FocusUnavailable" >pack://application:,,,/GustavNoesisGUI;component/Assets/FollowersOfZerthimon/Shared/Resources/ico_classRes_GZI_Psionic_Focus_missing.png</ImageSource>	
-	<ImageSource x:Key="SiaelIPORes">pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_Resource_d.png</ImageSource>
-	<ImageSource x:Key="SiaelIPOResUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_Resource_missing.png</ImageSource>
+	<ImageSource x:Key="SiaelIPORes">pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_d.png</ImageSource>
+	<ImageSource x:Key="SiaelIPOResUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_missing.png</ImageSource>
 	<ImageSource x:Key="OffHandExtraAttackCharge">pack://application:,,,/GustavNoesisGUI;component/Assets/OffHandExtraAttack/Shared/Resources/ico_extraAtt_d.png</ImageSource>
 	<ImageSource x:Key="OffHandExtraAttackChargeUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/OffHandExtraAttack/Shared/Resources/ico_extraAtt_missing.png</ImageSource>	
 	<!-- EDIT HERE -->
@@ -1660,10 +1660,10 @@
 
 	<ControlTemplate x:Key="ActionResources.ActionGroup.SiaelIPOResGroup" TargetType="ls:LSActionPoint">
 	    <ControlTemplate.Resources>
-	        <ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_Resource_h.png</ImageSource>
-	        <ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_Resource_d.png</ImageSource>
-	        <ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_Resource_spent.png</ImageSource>
-	        <ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/c_ico_Ress_Siael_IPO_Resource_missing.png</ImageSource>
+	        <ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_h.png</ImageSource>
+	        <ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_d.png</ImageSource>
+	        <ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/ico_Ress_Siael_IPO_spent.png</ImageSource>
+	        <ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/Shared/Resources/c_ico_Ress_Siael_IPO_missing.png</ImageSource>
 	    </ControlTemplate.Resources>
 	    <ContentControl ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
 	</ControlTemplate>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_c.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_c.xaml
@@ -448,10 +448,10 @@
 
 	<ControlTemplate x:Key="ActionResources.ActionGroup.SiaelIPOResGroup" TargetType="ls:LSActionPoint">
 		<ControlTemplate.Resources>
-			<ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_Resource_h.png</ImageSource>
-			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_Resource_d.png</ImageSource>
-			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_Resource_spent.png</ImageSource>
-			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_Resource_missing.png</ImageSource>
+			<ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_h.png</ImageSource>
+			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_d.png</ImageSource>
+			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_spent.png</ImageSource>
+			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_missing.png</ImageSource>
 		</ControlTemplate.Resources>
 		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
 	</ControlTemplate>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_c.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_c.xaml
@@ -446,5 +446,24 @@
 		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
 	</ControlTemplate>
 
+	<ControlTemplate x:Key="ActionResources.ActionGroup.SiaelIPOResGroup" TargetType="ls:LSActionPoint">
+		<ControlTemplate.Resources>
+			<ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_Resource_h.png</ImageSource>
+			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_Resource_d.png</ImageSource>
+			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_Resource_spent.png</ImageSource>
+			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_Resource_missing.png</ImageSource>
+		</ControlTemplate.Resources>
+		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
+
+	<ControlTemplate x:Key="ActionResources.ActionGroup.OffHandExtraAttackChargeGroup" TargetType="ls:LSActionPoint">
+		<ControlTemplate.Resources>
+			<ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/OffHandExtraAttack/ActionResources_c/Icons/c_ico_extraAtt_h.png</ImageSource>
+			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/OffHandExtraAttack/ActionResources_c/Icons/c_ico_extraAtt_d.png</ImageSource>
+			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/OffHandExtraAttack/ActionResources_c/Icons/c_ico_extraAtt_spent.png</ImageSource>
+			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/OffHandExtraAttack/ActionResources_c/Icons/c_ico_extraAtt_missing.png</ImageSource>
+		</ControlTemplate.Resources>
+		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
 	<!-- EDIT HERE -->
 </ResourceDictionary>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
@@ -614,16 +614,6 @@
 				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_d.png"/>
 			</DataTrigger>
 
-			<MultiDataTrigger>
-		        	<MultiDataTrigger.Conditions>
-				        <Condition Binding="{Binding ActionResource.TypeId}" Value="SiaelIPOResGroup"/>
-				        <Condition Binding="{Binding ActionResource.Value, Converter={StaticResource GreaterThanConverter}, ConverterParameter=5}" Value="True"/>
-			        </MultiDataTrigger.Conditions>
-		        	<MultiDataTrigger.Setters>
-				        <Setter TargetName="ResourceAmount" Property="Visibility" Value="Visible"/>
-		       		</MultiDataTrigger.Setters>
-		        </MultiDataTrigger>
-
 			<DataTrigger Binding="{Binding ActionResource.TypeId}" Value="OffHandExtraAttackCharge">
 				<Setter TargetName="ResourcePoints" Property="Visibility" Value="Collapsed"/>
 				<Setter TargetName="ResourcePointsStack" Property="Margin" Value="22,0,22,0"/>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
@@ -604,6 +604,24 @@
 				<Setter TargetName="LevelImage" Property="Margin" Value="-10,0,-10,0"/>
 				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/FollowersOfZerthimon/ActionResources_c/Icons/c_ico_classRes_GZI_Psionic_Focus_d.png"/>
 			</DataTrigger>
+
+			<DataTrigger Binding="{Binding ActionResource.TypeId}" Value="SiaelIPOResGroup">
+				<Setter TargetName="ResourcePoints" Property="Visibility" Value="Collapsed"/>
+				<Setter TargetName="ResourcePointsStack" Property="Margin" Value="22,0,22,0"/>
+				<Setter TargetName="ResourceAmount" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="LevelImage" Property="Margin" Value="-10,0,-10,0"/>
+				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_Resource_d.png"/>
+			</DataTrigger>
+
+			<DataTrigger Binding="{Binding ActionResource.TypeId}" Value="OffHandExtraAttackCharge">
+				<Setter TargetName="ResourcePoints" Property="Visibility" Value="Collapsed"/>
+				<Setter TargetName="ResourcePointsStack" Property="Margin" Value="22,0,22,0"/>
+				<Setter TargetName="ResourceAmount" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="LevelImage" Property="Margin" Value="-10,0,-10,0"/>
+				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/OffHandExtraAttack/ActionResources_c/Icons/c_ico_extraAtt_d.png"/>
+			</DataTrigger>
 			<!-- EDIT HERE -->
 
 			<!-- Please leave the below alone -->
@@ -1105,6 +1123,24 @@
 				<Setter TargetName="ResourceImage" Property="Fill">
 					<Setter.Value>
 						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/FollowersOfZerthimon/ActionResources_c/Icons/c_ico_classRes_GZI_Psionic_Focus_d.png" Stretch="Uniform"/>
+					</Setter.Value>
+				</Setter>
+				<Setter TargetName="ResourceImage" Property="Width" Value="50"/>
+			</DataTrigger>
+
+			<DataTrigger Binding="{Binding TypeId}" Value="SiaelIPORes">
+				<Setter TargetName="ResourceImage" Property="Fill">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_Resource_d.png" Stretch="Uniform"/>
+					</Setter.Value>
+				</Setter>
+				<Setter TargetName="ResourceImage" Property="Width" Value="50"/>
+			</DataTrigger>
+
+			<DataTrigger Binding="{Binding TypeId}" Value="OffHandExtraAttackCharge">
+				<Setter TargetName="ResourceImage" Property="Fill">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/OffHandExtraAttack/ActionResources_c/Icons/c_ico_extraAtt_d.png" Stretch="Uniform"/>
 					</Setter.Value>
 				</Setter>
 				<Setter TargetName="ResourceImage" Property="Width" Value="50"/>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
@@ -611,7 +611,7 @@
 				<Setter TargetName="ResourceAmount" Property="Visibility" Value="Visible"/>
 				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
 				<Setter TargetName="LevelImage" Property="Margin" Value="-10,0,-10,0"/>
-				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_Resource_d.png"/>
+				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_d.png"/>
 			</DataTrigger>
 
 			<DataTrigger Binding="{Binding ActionResource.TypeId}" Value="OffHandExtraAttackCharge">
@@ -1131,7 +1131,7 @@
 			<DataTrigger Binding="{Binding TypeId}" Value="SiaelIPORes">
 				<Setter TargetName="ResourceImage" Property="Fill">
 					<Setter.Value>
-						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_Resource_d.png" Stretch="Uniform"/>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_d.png" Stretch="Uniform"/>
 					</Setter.Value>
 				</Setter>
 				<Setter TargetName="ResourceImage" Property="Width" Value="50"/>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
@@ -614,6 +614,16 @@
 				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/IllithidPowersOverhaul/ActionResources_c/Icons/c_ico_Ress_Siael_IPO_d.png"/>
 			</DataTrigger>
 
+			<MultiDataTrigger>
+		        	<MultiDataTrigger.Conditions>
+				        <Condition Binding="{Binding ActionResource.TypeId}" Value="SiaelIPOResGroup"/>
+				        <Condition Binding="{Binding ActionResource.Value, Converter={StaticResource GreaterThanConverter}, ConverterParameter=5}" Value="True"/>
+			        </MultiDataTrigger.Conditions>
+		        	<MultiDataTrigger.Setters>
+				        <Setter TargetName="ResourceAmount" Property="Visibility" Value="Visible"/>
+		       		</MultiDataTrigger.Setters>
+		        </MultiDataTrigger>
+
 			<DataTrigger Binding="{Binding ActionResource.TypeId}" Value="OffHandExtraAttackCharge">
 				<Setter TargetName="ResourcePoints" Property="Visibility" Value="Collapsed"/>
 				<Setter TargetName="ResourcePointsStack" Property="Margin" Value="22,0,22,0"/>


### PR DESCRIPTION
Hey there!

This time I got two mods at once, one resource each.

First is Dual Wielding Overhaul (internally labelled as OffHandExtraAttack). It creates a new and separate queue of extra attacks for the off-hand, and works with dual wielding, by adding 2 new dual wield attack-spells. If/while testing, don't use the base game dual wield toggle (set to off). The resource I made is simply a counter for the off-hand extra attacks. It regenerates on turn, and account to Extra Attack and Improved Extra Attack only. Controller fully supported.

Second is for my Illithid Powers Overhaul mod, for 2.0 I'm still cooking. I won't share the files as it's still a hot mess, but it's well tested for resource icons on my part, and everything works nicely. Controller fully supported too. I hope you understand and can trust me :)
[Off Hand Extra Attacks.zip](https://github.com/TheRealDjmr/BG3ImprovedUI/files/13451854/Off.Hand.Extra.Attacks.zip)


