### PR TITLE
Implement Action Resource Icons for upcoming Class Mod

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons.xaml
@@ -189,6 +189,12 @@
 	<ImageSource x:Key="EM_Elemental_EssenceUnavailable" >pack://application:,,,/GustavNoesisGUI;component/Assets/Elemental_Mayhem/Shared/Resources/ico_classRes_EM_Elemental_Essence_missing.png</ImageSource>	
 	<ImageSource x:Key="Z_TheurgyChannelArcana">pack://application:,,,/GustavNoesisGUI;component/Assets/Z_TheurgyWizard/Shared/Resources/ico_theurgist_ChannelArcana.png</ImageSource>
 	<ImageSource x:Key="Z_TheurgyChannelArcanaUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/Z_TheurgyWizard/Shared/Resources/ico_theurgist_ChannelArcana_missing.png</ImageSource>
+    <ImageSource x:Key="KWEnergyPoint">pack://application:,,,/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_ki.png</ImageSource>
+	<ImageSource x:Key="KWEnergyPointUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_ki_missing.png</ImageSource>
+    <ImageSource x:Key="KWZenkaiPoint">pack://application:,,,/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_sorc_d.png</ImageSource>
+	<ImageSource x:Key="KWZenkaiPointUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_sorc_missing.png</ImageSource>
+    <ImageSource x:Key="KWSenzuPoint">pack://application:,,,/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_NaturalRecovery.png</ImageSource>
+	<ImageSource x:Key="KWSenzuPointUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_NaturalRecovery_missing.png</ImageSource>
 	<!-- EDIT HERE -->
 
 	<!-- This is the icon that appears on the tooltip -->
@@ -328,6 +334,15 @@
 			</DataTrigger>
 			<DataTrigger Binding="{Binding TypeId}" Value="Theurgist_Channel_Arcana">
 				<Setter Property="Source" Value="{StaticResource Z_TheurgyChannelArcana}"/>
+			</DataTrigger>
+            <DataTrigger Binding="{Binding TypeId}" Value="KW_Energy">
+				<Setter Property="Source" Value="{StaticResource KWEnergyPoint}"/>
+			</DataTrigger>
+            <DataTrigger Binding="{Binding TypeId}" Value="KW_ZenkaiCharge">
+				<Setter Property="Source" Value="{StaticResource KWZenkaiPoint}"/>
+			</DataTrigger>
+            <DataTrigger Binding="{Binding TypeId}" Value="KW_SenzuBeanCharge">
+				<Setter Property="Source" Value="{StaticResource KWSenzuPoint}"/>
 			</DataTrigger>
 			<!-- EDIT HERE -->
 		</Style.Triggers>
@@ -1171,6 +1186,39 @@
 					<Setter Property="Source" Value="{StaticResource Z_TheurgyChannelArcanaUnavailable}"/>
 				</MultiDataTrigger.Setters>
 			</MultiDataTrigger>
+        
+      <MultiDataTrigger>
+				<MultiDataTrigger.Conditions>
+					<Condition Binding="{Binding TypeId}" Value="KW_Energy"/>
+					<Condition Binding="{Binding Value}" Value="0"/>
+					<Condition Binding="{Binding IgnoreCost}" Value="False"/>
+				</MultiDataTrigger.Conditions>
+				<MultiDataTrigger.Setters>
+					<Setter Property="Source" Value="{StaticResource KWEnergyPointUnavailable}"/>
+				</MultiDataTrigger.Setters>
+			</MultiDataTrigger>
+        
+      <MultiDataTrigger>
+				<MultiDataTrigger.Conditions>
+					<Condition Binding="{Binding TypeId}" Value="KW_ZenkaiCharge"/>
+					<Condition Binding="{Binding Value}" Value="0"/>
+					<Condition Binding="{Binding IgnoreCost}" Value="False"/>
+				</MultiDataTrigger.Conditions>
+				<MultiDataTrigger.Setters>
+					<Setter Property="Source" Value="{StaticResource KWZenkaiPointUnavailable}"/>
+				</MultiDataTrigger.Setters>
+			</MultiDataTrigger>
+        
+      <MultiDataTrigger>
+				<MultiDataTrigger.Conditions>
+					<Condition Binding="{Binding TypeId}" Value="KW_SenzuBeanCharge"/>
+					<Condition Binding="{Binding Value}" Value="0"/>
+					<Condition Binding="{Binding IgnoreCost}" Value="False"/>
+				</MultiDataTrigger.Conditions>
+				<MultiDataTrigger.Setters>
+					<Setter Property="Source" Value="{StaticResource KWSenzuPointUnavailable}"/>
+				</MultiDataTrigger.Setters>
+			</MultiDataTrigger>
 			<!-- EDIT HERE -->
 		</Style.Triggers>
 	</Style>
@@ -1724,6 +1772,36 @@
 			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/Z_TheurgyWizard/Shared/Resources/ico_theurgist_ChannelArcana.png</ImageSource>
 			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/Z_TheurgyWizard/Shared/Resources/ico_theurgist_ChannelArcana_spent.png</ImageSource>
 			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/Z_TheurgyWizard/Shared/Resources/ico_theurgist_ChannelArcana_missing.png</ImageSource>
+		</ControlTemplate.Resources>
+		<ContentControl ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
+    
+    <ControlTemplate x:Key="ActionResources.ActionGroup.KWEnergyActionGroup" TargetType="ls:LSActionPoint">
+		<ControlTemplate.Resources>
+			<ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_ki_h.png</ImageSource>
+			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_ki.png</ImageSource>
+			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_ki_spent.png</ImageSource>
+			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_ki_missing.png</ImageSource>
+		</ControlTemplate.Resources>
+		<ContentControl ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
+    
+    <ControlTemplate x:Key="ActionResources.ActionGroup.KWZekaiActionGroup" TargetType="ls:LSActionPoint">
+		<ControlTemplate.Resources>
+			<ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_sorc_h.png</ImageSource>
+			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_sorc_d.png</ImageSource>
+			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_sorc_spent.png</ImageSource>
+			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_sorc_missing.png</ImageSource>
+		</ControlTemplate.Resources>
+		<ContentControl ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
+    
+    <ControlTemplate x:Key="ActionResources.ActionGroup.KWSenzuActionGroup" TargetType="ls:LSActionPoint">
+		<ControlTemplate.Resources>
+			<ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_NaturalRecovery_h.png</ImageSource>
+			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_NaturalRecovery.png</ImageSource>
+			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_NaturalRecovery_spent.png</ImageSource>
+			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/Shared/Resources/ico_classRes_NaturalRecovery_missing.png</ImageSource>
 		</ControlTemplate.Resources>
 		<ContentControl ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
 	</ControlTemplate>
@@ -2608,6 +2686,50 @@
 			<MultiDataTrigger>
 				<MultiDataTrigger.Conditions>
 					<Condition Binding="{Binding TypeId}" Value="Theurgist_Channel_Arcana"/>
+					<Condition Binding="{Binding Value, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}" Value="True"/>
+				</MultiDataTrigger.Conditions>
+				<MultiDataTrigger.Setters>
+					<Setter Property="Margin" Value="0,-15,0,0"/>
+				</MultiDataTrigger.Setters>
+			</MultiDataTrigger>
+        <DataTrigger Binding="{Binding TypeId}" Value="KW_Energy">
+				<Setter Property="ActionPointTemplate" Value="{DynamicResource ActionResources.ActionGroup.KWEnergyActionGroup}"/>
+				<Setter Property="MaxGroupActionPoints" Value="1"/>
+				<Setter Property="ActionPointSize" Value="{DynamicResource ActionResources.ActionPointSize}" />
+			</DataTrigger>
+			<MultiDataTrigger>
+				<MultiDataTrigger.Conditions>
+					<Condition Binding="{Binding TypeId}" Value="KW_Energy"/>
+					<Condition Binding="{Binding Value, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}" Value="True"/>
+				</MultiDataTrigger.Conditions>
+				<MultiDataTrigger.Setters>
+					<Setter Property="Margin" Value="0,-15,0,0"/>
+				</MultiDataTrigger.Setters>
+			</MultiDataTrigger>
+        
+        <DataTrigger Binding="{Binding TypeId}" Value="KW_ZenkaiCharge">
+				<Setter Property="ActionPointTemplate" Value="{DynamicResource ActionResources.ActionGroup.KWZekaiActionGroup}"/>
+				<Setter Property="MaxGroupActionPoints" Value="1"/>
+				<Setter Property="ActionPointSize" Value="{DynamicResource ActionResources.ActionPointSize}" />
+			</DataTrigger>
+			<MultiDataTrigger>
+				<MultiDataTrigger.Conditions>
+					<Condition Binding="{Binding TypeId}" Value="KW_ZenkaiCharge"/>
+					<Condition Binding="{Binding Value, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}" Value="True"/>
+				</MultiDataTrigger.Conditions>
+				<MultiDataTrigger.Setters>
+					<Setter Property="Margin" Value="0,-15,0,0"/>
+				</MultiDataTrigger.Setters>
+			</MultiDataTrigger>
+        
+        <DataTrigger Binding="{Binding TypeId}" Value="KW_SenzuBeanCharge">
+				<Setter Property="ActionPointTemplate" Value="{DynamicResource ActionResources.ActionGroup.KWSenzuActionGroup}"/>
+				<Setter Property="MaxGroupActionPoints" Value="1"/>
+				<Setter Property="ActionPointSize" Value="{DynamicResource ActionResources.ActionPointSize}" />
+			</DataTrigger>
+			<MultiDataTrigger>
+				<MultiDataTrigger.Conditions>
+					<Condition Binding="{Binding TypeId}" Value="KW_SenzuBeanCharge"/>
 					<Condition Binding="{Binding Value, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}" Value="True"/>
 				</MultiDataTrigger.Conditions>
 				<MultiDataTrigger.Setters>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_c.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_c.xaml
@@ -485,5 +485,35 @@
 		</ControlTemplate.Resources>
 		<ContentControl ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
 	</ControlTemplate>
+    
+    <ControlTemplate x:Key="ActionResources.ActionGroup.KWEnergyActionGroup" TargetType="ls:LSActionPoint">
+		<ControlTemplate.Resources>
+			<ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_ki_h.png</ImageSource>
+			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_ki.png</ImageSource>
+			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_ki_spent.png</ImageSource>
+			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_ki_missing.png</ImageSource>
+		</ControlTemplate.Resources>
+		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
+
+	<ControlTemplate x:Key="ActionResources.ActionGroup.KWZenkaiActionGroup" TargetType="ls:LSActionPoint">
+		<ControlTemplate.Resources>
+			<ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_sorc_h.png</ImageSource>
+			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_sorc.png</ImageSource>
+			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_sorc_spent.png</ImageSource>
+			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_sorc_missing.png</ImageSource>
+		</ControlTemplate.Resources>
+		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
+
+	<ControlTemplate x:Key="ActionResources.ActionGroup.KWZenkaiActionGroup" TargetType="ls:LSActionPoint">
+		<ControlTemplate.Resources>
+			<ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_NaturalRecovery_h.png</ImageSource>
+			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_NaturalRecovery.png</ImageSource>
+			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_NaturalRecovery_spent.png</ImageSource>
+			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_NaturalRecovery_missing.png</ImageSource>
+		</ControlTemplate.Resources>
+		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
 	<!-- EDIT HERE -->
 </ResourceDictionary>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_k.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_k.xaml
@@ -48,6 +48,9 @@
 	<BitmapImage x:Key="MysticPsiPointsResourceIcon" UriSource="pack://application:,,,/GustavNoesisGUI;component/Assets/Mystic/CC/icons_resources/ico_classRes_PsiPointsResource.png" />
 	<BitmapImage x:Key="MysticPsionicMasteryResourceIcon" UriSource="pack://application:,,,/GustavNoesisGUI;component/Assets/Mystic/CC/icons_resources/ico_classRes_PsionicMasteryResource.png" />
 	<BitmapImage x:Key="SpellbaneDiceIcon" UriSource="pack://application:,,,/GustavNoesisGUI;component/Assets/Spellbreaker/CC/icons_resources/ico_classRes_SpellbaneDie_d.png" />
+    <BitmapImage x:Key="KWEnergyPointIcon" UriSource="pack://application:,,,/GustavNoesisGUI;component/Assets/CC/icons_resources/ico_classRes_ki.png" />
+    <BitmapImage x:Key="KWZenkaiPointIcon" UriSource="pack://application:,,,/GustavNoesisGUI;component/Assets/CC/icons_resources/ico_classRes_sorc_d.png" />
+    <BitmapImage x:Key="KWSenzuPointIcon" UriSource="pack://application:,,,/GustavNoesisGUI;component/Assets/CC/icons_resources/ico_classRes_NaturalRecovery.png" />
 	<!-- EDIT HERE -->
 
     <!-- Reference entries below -->
@@ -149,6 +152,15 @@
 			</DataTrigger>
 			<DataTrigger Binding="{Binding TypeId}" Value="SpellbaneDie">
 				<Setter Property="Source" Value="{StaticResource SpellbaneDiceIcon}"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding TypeId}" Value="KW_Energy">
+				<Setter Property="Source" Value="{StaticResource KWEnergyPointIcon}"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding TypeId}" Value="KW_ZenkaiCharge">
+				<Setter Property="Source" Value="{StaticResource KWZenkaiPointIcon}"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding TypeId}" Value="KW_SenzuBeanCharge">
+				<Setter Property="Source" Value="{StaticResource KWSenzuPointIcon}"/>
 			</DataTrigger>
 			<!-- EDIT HERE -->
         </Style.Triggers>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
@@ -646,6 +646,30 @@
 				<Setter TargetName="LevelImage" Property="Margin" Value="-10,0,-10,0"/>
 				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/OffHandExtraAttack/ActionResources_c/Icons/c_ico_extraAtt_d.png"/>
 			</DataTrigger>
+            
+            <DataTrigger Binding="{Binding ActionResource.TypeId}" Value="KW_Energy">
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_ki.png"/>
+				<Setter TargetName="ActionResourceBackground" Property="Fill" Value="{StaticResource ActionResource.KiPoint}"/>
+				<Setter TargetName="ActionResourceBackgroundStroke" Property="Stroke" Value="{StaticResource ActionResource.KiPoint}"/>
+				<Setter TargetName="ResourceLabel" Property="Text" Value="{Binding Source='h65345978g6d61g4572g87e0ga850a81ca9bc', Converter={StaticResource TranslatedStringConverter}}"/>
+			</DataTrigger>
+            
+            <DataTrigger Binding="{Binding ActionResource.TypeId}" Value="KW_SenzuBeanCharge">
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_NaturalRecovery.png"/>
+				<Setter TargetName="ActionResourceBackground" Property="Fill" Value="{StaticResource ActionResource.NaturalRecovery}"/>
+				<Setter TargetName="ActionResourceBackgroundStroke" Property="Stroke" Value="{StaticResource ActionResource.NaturalRecovery}"/>
+				<Setter TargetName="ResourceLabel" Property="Text" Value="{Binding Source='h17002d15gd024g41f7ga17bg49b42c867b42', Converter={StaticResource TranslatedStringConverter}}"/>
+			</DataTrigger>
+            
+            <DataTrigger Binding="{Binding ActionResource.TypeId}" Value="KW_ZenkaiCharge">
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_sorc.png"/>
+				<Setter TargetName="ActionResourceBackground" Property="Fill" Value="{StaticResource ActionResource.SorceryPoint}"/>
+				<Setter TargetName="ActionResourceBackgroundStroke" Property="Stroke" Value="{StaticResource ActionResource.SorceryPoint}"/>
+				<Setter TargetName="ResourceLabel" Property="Text" Value="{Binding Source='h2b304762g10e7g4f6cg96c4g1432137ef83e', Converter={StaticResource TranslatedStringConverter}}"/>
+			</DataTrigger>
 			<!-- EDIT HERE -->
 
 			<!-- Please leave the below alone -->
@@ -1186,6 +1210,39 @@
 					</Setter.Value>
 				</Setter>
 				<Setter TargetName="ResourceImage" Property="Width" Value="50"/>
+			</DataTrigger>
+            
+			<DataTrigger Binding="{Binding TypeId}" Value="KW_Energy">
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_ki.png"/>
+				<Setter TargetName="ResourceImage" Property="Fill">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_ki_point.png"
+															TileMode="Tile" Stretch="None" ViewportUnits="Absolute" Viewport="0,0,25,64" ViewboxUnits="Absolute" Viewbox="8,0,25,64"/>
+					</Setter.Value>
+				</Setter>
+			</DataTrigger>
+            
+            <DataTrigger Binding="{Binding TypeId}" Value="KW_ZenkaiCharge">
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_sorc.png"/>
+				<Setter TargetName="ResourceImage" Property="Fill">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_sorc_point.png"
+															TileMode="Tile" Stretch="None" ViewportUnits="Absolute" Viewport="0,0,25,64" ViewboxUnits="Absolute" Viewbox="8,0,25,64"/>
+					</Setter.Value>
+				</Setter>
+			</DataTrigger>
+            
+			<DataTrigger Binding="{Binding TypeId}" Value="KW_SenzuBeanCharge">
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_NaturalRecovery.png"/>
+				<Setter TargetName="ResourceImage" Property="Fill">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/ActionResources_c/Icons/c_ico_classRes_NaturalRecovery_point.png"
+															TileMode="Tile" Stretch="None" ViewportUnits="Absolute" Viewport="0,0,25,64" ViewboxUnits="Absolute" Viewbox="8,0,25,64"/>
+					</Setter.Value>
+				</Setter>
 			</DataTrigger>
 			<!-- EDIT HERE -->
 

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ClassIcons.xaml
@@ -171,6 +171,9 @@
 			<DataTrigger Binding="{Binding IDString}" Value="Diemnocturnum">
 				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/Diemnocturnum/ClassIcons/Diemnocturnum.png"/>
 			</DataTrigger>
+			<DataTrigger Binding="{Binding IDString}" Value="KiWarrior">
+				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/KiWarrior/ClassIcons/KiWarrior.png"/>
+			</DataTrigger>
 			<!--EDIT HERE-->
 		</Style.Triggers>
 	</Style>
@@ -222,6 +225,9 @@
 			</DataTrigger>
 			<DataTrigger Binding="{Binding IDString}" Value="Diemnocturnum">
 				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/Diemnocturnum/ClassIcons/hotbar/Diemnocturnum_hotbar.png"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding IDString}" Value="KiWarrior">
+				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/KiWarrior/ClassIcons/hotbar/KiWarrior.png"/>
 			</DataTrigger>
 			<!--EDIT HERE-->
 		</Style.Triggers>
@@ -699,6 +705,12 @@
 			<DataTrigger Binding="{Binding SubclassIDString}" Value="DeathSoul">
 				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/DeathSoul/ClassIcons/sorcerer_DeathSoul.dds"/>
 			</DataTrigger>
+			<DataTrigger Binding="{Binding SubclassIDString}" Value="Saiyan_Heritage">
+				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/KiWarrior/ClassIcons/Saiyan_Heritage.png"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding SubclassIDString}" Value="Z_Fighter">
+				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/KiWarrior/ClassIcons/Z_Fighter.png"/>
+			</DataTrigger>
 			<!--EDIT HERE-->
 		</Style.Triggers>
 	</Style>
@@ -861,6 +873,12 @@
 			</DataTrigger>
 			<DataTrigger Binding="{Binding SubclassIDString}" Value="DeathSoul">
 				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/DeathSoul/ClassIcons/hotbar/sorcerer_DeathSoul.dds"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding SubclassIDString}" Value="Saiyan_Heritage">
+				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/KiWarrior/ClassIcons/hotbar/Saiyan_Heritage.png"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding SubclassIDString}" Value="Z_Fighter">
+				<Setter Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/KiWarrior/ClassIcons/hotbar/Z_Fighter.png"/>
 			</DataTrigger>
 			<!--EDIT HERE-->
 		</Style.Triggers>


### PR DESCRIPTION
Just a PR to implement icons for my upcoming Ki Warrior class mod (It's not up on Nexus but i can provide a .pak of the mod if the team needs to see the mod in action). It uses the existing Ki, Sorcery Point and Natural Recovery icons rather than new icons, as those are sufficient for me right now.

![image](https://github.com/TheRealDjmr/BG3ImprovedUI/assets/4214215/026e7ccd-0e28-4a17-84ae-fc70c24c7793)

![image](https://github.com/TheRealDjmr/BG3ImprovedUI/assets/4214215/d6e7c21c-fa90-47da-84cf-6f3403e78e75)

![image](https://github.com/TheRealDjmr/BG3ImprovedUI/assets/4214215/413d2ef1-ee53-4be1-81ae-f27b3d816def)

![image](https://github.com/TheRealDjmr/BG3ImprovedUI/assets/4214215/6174c0ca-dce5-49b4-bc9c-4a157aad5cac)
