### PR TITLE
Race and deity icon for custom races

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/IUI_DeityIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_DeityIcons.xaml
@@ -665,6 +665,27 @@
 					</Setter.Value>
 				</Setter>
 			</DataTrigger>
+			<DataTrigger Binding="{Binding Guid}" Value="fad53842-c20b-4803-8013-6ad2d61f90d2">
+				<Setter Property="OpacityMask">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/DemonPlayerRace/CC/icons_deities/LAR_ILSENSINE.png"/>
+					</Setter.Value>
+				</Setter>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding Guid}" Value="35e15ee1-4627-4814-9819-371979fd3411">
+				<Setter Property="OpacityMask">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/SolarPlayerRace/CC/icons_deities/LAR_MILIL.png"/>
+					</Setter.Value>
+				</Setter>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding Guid}" Value="e56ec530-dd8f-4074-b7b8-3b0d31a9ce6c">
+				<Setter Property="OpacityMask">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/SolarPlayerRace/CC/icons_deities/LAR_TORM.png"/>
+					</Setter.Value>
+				</Setter>
+			</DataTrigger>
 			<!-- EDIT HERE -->
 		</Style.Triggers>
 	</Style>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_RaceIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_RaceIcons.xaml
@@ -1160,6 +1160,48 @@
 					</Setter.Value>
 				</Setter>
 			</DataTrigger>
+			<DataTrigger Binding="{Binding Guid}" Value="380159a0-602e-4d89-bc61-11fd7174c5b8">
+				<Setter Property="OpacityMask">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/SolarPlayerRace/CC/icons_races/LAR_SOLAR.png"/>
+					</Setter.Value>
+				</Setter>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding Guid}" Value="29c2141d-75bb-486a-8d37-a4d668f90e8d">
+				<Setter Property="OpacityMask">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/SolarPlayerRace/CC/icons_races/LAR_SOLAR.png"/>
+					</Setter.Value>
+				</Setter>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding Guid}" Value="af52d07e-5561-4bd7-9614-28ffe15925a7">
+				<Setter Property="OpacityMask">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/DemonPlayerRace/CC/icons_races/LAR_DEMON.png"/>
+					</Setter.Value>
+				</Setter>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding Guid}" Value="417b17e1-6a61-4611-9086-ac025160c6cb">
+				<Setter Property="OpacityMask">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/DemonPlayerRace/CC/icons_races/LAR_DEMON.png"/>
+					</Setter.Value>
+				</Setter>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding Guid}" Value="14df0fc9-fe0d-4f53-a506-a3094a222717">
+				<Setter Property="OpacityMask">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/DisplacerPlayerRace/CC/icons_races/LAR_DISPLACER.png"/>
+					</Setter.Value>
+				</Setter>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding Guid}" Value="376402e1-1487-4b0f-8fe1-69b240d696fb">
+				<Setter Property="OpacityMask">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/DisplacerPlayerRace/CC/icons_races/LAR_DISPLACER.png"/>
+					</Setter.Value>
+				</Setter>
+			</DataTrigger>
 			<!-- EDIT HERE -->
 		</Style.Triggers>
 	</Style>


### PR DESCRIPTION
If I'm doing something obviously wrong I'm so sorry - but I'm having a lot of trouble making the deity icons show up. The race icons fortunately do work on my end.

Adds 3 race icons, same image shared between race and its single subrace; 3 deity icons, 2 in solar, 1 in demon(and none of them seems to work).

Mod files:
[LAR_VariousPlayerRaces.zip](https://github.com/TheRealDjmr/BG3ImprovedUI/files/13978884/LAR_VariousPlayerRaces.zip)

![20240117220817_1](https://github.com/TheRealDjmr/BG3ImprovedUI/assets/156967997/0ce80b58-ec3c-43d8-8faa-fcc1c3504d0f)

The icons are all in the same format, resolution, all .DDS, etc. etc. so they should be good(?).
<img width="931" alt="Screenshot 2024-01-18 111351" src="https://github.com/TheRealDjmr/BG3ImprovedUI/assets/156967997/d01a04dc-1961-444a-840c-5b909b92e433">
