### PR TITLE
Allow racial PassiveSelectors to enable levelup race tab visibility

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/CCLib_k.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/CCLib_k.xaml
@@ -2649,11 +2649,6 @@
 
 					<ItemsControl ItemsSource="{Binding FilteredItems, ElementName=SubClassPassiveFeatures}" ItemTemplate="{StaticResource ProgressionSpellsTemplate}" Visibility="{Binding FilteredItems.Count, ElementName=SubClassPassiveFeatures, Converter={StaticResource CountToVisibilityConverter}}" Margin="0,20,0,0"/>
 
-					<!-- MOD START - Racial passive selection -->
-					<ItemsControl ItemsSource="{Binding FilteredItems, ElementName=RacePassiveFeatures}" ItemTemplate="{StaticResource ProgressionSpellsTemplate}" Visibility="{Binding FilteredItems.Count, ElementName=RacePassiveFeatures, Converter={StaticResource CountToVisibilityConverter}}" Margin="0,20,0,0"/>
-					<ItemsControl ItemsSource="{Binding FilteredItems, ElementName=SubRacePassiveFeatures}" ItemTemplate="{StaticResource ProgressionSpellsTemplate}" Visibility="{Binding FilteredItems.Count, ElementName=SubRacePassiveFeatures, Converter={StaticResource CountToVisibilityConverter}}" Margin="0,20,0,0"/>
-					<!-- MOD END -->
-
 					<StackPanel x:Name="PiercingSelector" Visibility="Collapsed" Margin="0,50,0,0">
 						<TextBlock Text="{Binding Source='h261cce55g1d1eg4c09g9675ge5c1be13e820', Converter={StaticResource TranslatedStringConverter}}" Style="{StaticResource PanelSubHeaderText}"/>
 

--- a/ImprovedUI/Public/Game/GUI/Widgets/CharacterLevelUp.xaml
+++ b/ImprovedUI/Public/Game/GUI/Widgets/CharacterLevelUp.xaml
@@ -452,7 +452,7 @@
 					<DataTrigger Binding="{Binding FilteredItems.Count, ElementName=RaceProgressions, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True">
 						<Setter TargetName="raceTab" Property="Visibility" Value="Visible"/>
 					</DataTrigger>
-					<!-- MOD START - Race tab should also be enabled on LevelUp if there are subrace spell selections and equipment available -->
+					<!-- MOD START - Race tab should also be enabled on LevelUp if there are (sub)race selections available -->
 					<DataTrigger Binding="{Binding FilteredItems.Count, ElementName=SubRaceSpellSelectors, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True">
 						<Setter TargetName="raceTab" Property="Visibility" Value="Visible"/>
 					</DataTrigger>
@@ -460,6 +460,12 @@
 						<Setter TargetName="raceTab" Property="Visibility" Value="Visible"/>
 					</DataTrigger>
 					<DataTrigger Binding="{Binding FilteredItems.Count, ElementName=SubRaceEquipments, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True">
+						<Setter TargetName="raceTab" Property="Visibility" Value="Visible"/>
+					</DataTrigger>
+					<DataTrigger Binding="{Binding FilteredItems.Count, ElementName=RacePassiveSelectors, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True">
+						<Setter TargetName="raceTab" Property="Visibility" Value="Visible"/>
+					</DataTrigger>
+					<DataTrigger Binding="{Binding FilteredItems.Count, ElementName=SubRacePassiveSelectors, Converter={StaticResource GreaterThanConverter}, ConverterParameter=0}" Value="True">
 						<Setter TargetName="raceTab" Property="Visibility" Value="Visible"/>
 					</DataTrigger>
 					<!-- MOD END -->
@@ -1102,9 +1108,9 @@ ConverterParameter=0}" Value="True"/>
 										<!-- MOD END -->
 
 										<!-- MOD START - Race tab shows preview of racial passive if available -->
-										<ItemsControl x:Name="racePassiveFeatures" ItemsSource="{Binding FilteredItems, ElementName=RacePassiveFeatures}" ItemTemplate="{StaticResource LevelUpPassiveSelectorPreviewTemplate}" Visibility="{Binding FilteredItems.Count, ElementName=RacePassiveFeatures, Converter={StaticResource CountToVisibilityConverter}}" Margin="0,0,0,20"/>
+										<ItemsControl x:Name="racePassiveSelectors" ItemsSource="{Binding FilteredItems, ElementName=RacePassiveSelectors}" ItemTemplate="{StaticResource LevelUpPassiveSelectorPreviewTemplate}" Visibility="{Binding FilteredItems.Count, ElementName=RacePassiveSelectors, Converter={StaticResource CountToVisibilityConverter}}" Margin="0,0,0,20"/>
 
-										<ItemsControl x:Name="subRacePassiveFeatures" ItemsSource="{Binding FilteredItems, ElementName=SubRacePassiveFeatures}" ItemTemplate="{StaticResource LevelUpPassiveSelectorPreviewTemplate}" Visibility="{Binding FilteredItems.Count, ElementName=SubRacePassiveFeatures, Converter={StaticResource CountToVisibilityConverter}}" Margin="0,0,0,20"/>
+										<ItemsControl x:Name="subRacePassiveSelectors" ItemsSource="{Binding FilteredItems, ElementName=SubRacePassiveSelectors}" ItemTemplate="{StaticResource LevelUpPassiveSelectorPreviewTemplate}" Visibility="{Binding FilteredItems.Count, ElementName=SubRacePassiveSelectors, Converter={StaticResource CountToVisibilityConverter}}" Margin="0,0,0,20"/>
 										<!-- MOD END -->
 
 										<ContentControl Template="{DynamicResource LevelUpShowFeaturesTemplate}" DataContext="{Binding ProgressionData.RaceProgression.Other}" Content="{Binding Source='hd0d992ebg43f8g429bgbf11g0cbf54d84d4e', Converter={StaticResource TranslatedStringConverter}}" Visibility="{Binding Count, Converter={StaticResource CountToVisibilityConverter}}" HorizontalAlignment="Center" Margin="0,0,0,20"/>
@@ -1436,8 +1442,8 @@ ConverterParameter=0}" Value="True"/>
 		<ls:CollectionFilterBehavior x:Name="SubClassSpellSelectors" ItemsSource="{Binding ClassProgressionDetails.SpellSelectors}" Predicate="{Binding IsSubProgressionPredicate}"/>
 
 		<!-- MOD START - Filter racial passives and racial equipment -->
-		<ls:CollectionFilterBehavior x:Name="RacePassiveFeatures" ItemsSource="{Binding RaceProgressionDetails.NotSubPassiveSelectors}" Predicate="{Binding IsNotSubProgressionPredicate}"/>
-		<ls:CollectionFilterBehavior x:Name="SubRacePassiveFeatures" ItemsSource="{Binding RaceProgressionDetails.SubPassiveSelectors}" Predicate="{Binding IsSubProgressionPredicate}"/>
+		<ls:CollectionFilterBehavior x:Name="RacePassiveSelectors" ItemsSource="{Binding RaceProgressionDetails.NotSubPassiveSelectors}"/>
+		<ls:CollectionFilterBehavior x:Name="SubRacePassiveSelectors" ItemsSource="{Binding RaceProgressionDetails.SubPassiveSelectors}"/>
 		<ls:CollectionFilterBehavior x:Name="RaceEquipments" ItemsSource="{Binding RaceProgressionDetails.NotSubEquipmentSelectors}" Predicate="{Binding IsNotSubProgressionPredicate}"/>
 		<ls:CollectionFilterBehavior x:Name="SubRaceEquipments" ItemsSource="{Binding RaceProgressionDetails.SubEquipmentSelectors}" Predicate="{Binding IsSubProgressionPredicate}"/>
 		<!-- MOD END -->


### PR DESCRIPTION
## Problem
It was discovered (https://github.com/TheRealDjmr/BG3ImprovedUI/issues/136#issuecomment-1953227148) that PassiveSelectors weren't showing up in levelup (progression node levels >1) if implemented as the only selector type. That is, the race tab was not becoming visible during levelup in order to choose a passive, though the "Choices Pending!" warning remained and barred players from proceeding. The race tab (and passive selection) _did_ appear if the passive was added to CC (level 1), or if it was added in conjunction with another, [non-Passive]Selector.

Turns out this is because we erroneously left out the (sub)racial selectors from the visibility triggers for the race tab. 🤦‍♀️

## Summary of Changes
This PR corrects the aforementioned oversight.

### Bonus
I also:
* renamed the collection filters from `RacePassiveFeatures` and `SubRacePassiveFeatures` to `[...]Selectors` for better clarity/coherence. 
* removed the predicate from the filters, as that has apparently also become obsolete and actually a hindrance to our intended functionality.
* re-enabled the previously-functional,-at-some-point-defunct small QOL visual of the "Gained [a] Passive" preview on the race tab (in levelup) if a PassiveSelector is present. (Similar to the spell selection preview.)
* removed a code block form `CCLib_k.xaml` that was completely unnecessary, actually. Or, perhaps, has become obsolete since its original implementation.

## Screenshots

### Before
![20240220214930_1](https://github.com/TheRealDjmr/BG3ImprovedUI/assets/83232936/529e3631-0712-4a62-96b2-78b63b4da526)

### After
![20240220214426_1](https://github.com/TheRealDjmr/BG3ImprovedUI/assets/83232936/ba7ed320-0854-4c3b-8f43-f62b0ca1d7f3)
