### PR TITLE
Add Race and Resource icons for Mori's Astral Elves

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons.xaml
@@ -275,8 +275,9 @@
 	<ImageSource x:Key="GSAmmoUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/Tet42_Gunslinger/Shared/Resources/ico_classRes_GSAmmo_missing.png</ImageSource>
 	<ImageSource x:Key="GSAmmoOffhand">pack://application:,,,/GustavNoesisGUI;component/Assets/Tet42_Gunslinger/Shared/Resources/ico_classRes_GSAmmoOffhand_d.png</ImageSource>
 	<ImageSource x:Key="GSAmmoOffhandUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/Tet42_Gunslinger/Shared/Resources/ico_classRes_GSAmmoOffhand_missing.png</ImageSource>
-	<!-- EDIT HERE -->
-  
+  	<ImageSource x:Key="StarlightStepCharges">pack://application:,,,/GustavNoesisGUI;component/Assets/MoriAstralElf/Shared/Resources/ico_StarlightStepCharges_d.png</ImageSource>
+	<ImageSource x:Key="StarlightStepChargesUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/MoriAstralElf/Shared/Resources/ico_StarlightStepCharges_missing.png</ImageSource>
+	<!-- EDIT HERE -->	
 	<!-- This is the icon that appears on the tooltip -->
 	<Style TargetType="Image" x:Key="IUI_ActionResourceTypeIdToSource" BasedOn="{StaticResource IUI_ActionResourceTypeIdToSourceDefault}">
 		<Style.Triggers>
@@ -552,6 +553,9 @@
 			</DataTrigger>
 			<DataTrigger Binding="{Binding TypeId}" Value="GSAmmoOffhand">
 				<Setter Property="Source" Value="{StaticResource GSAmmoOffhand}"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding TypeId}" Value="StarlightStepCharges">
+				<Setter Property="Source" Value="{StaticResource StarlightStepCharges}"/>												   
 			</DataTrigger>
 			<!-- EDIT HERE -->
 		</Style.Triggers>
@@ -1855,6 +1859,16 @@
 					<Setter Property="Source" Value="{StaticResource GSAmmoOffhandUnavailable}"/>
 				</MultiDataTrigger.Setters>
 			</MultiDataTrigger>
+			<MultiDataTrigger>
+				<MultiDataTrigger.Conditions>
+					<Condition Binding="{Binding TypeId}" Value="StarlightStepCharges"/>
+					<Condition Binding="{Binding Value}" Value="0"/>
+					<Condition Binding="{Binding IgnoreCost}" Value="False"/>
+				</MultiDataTrigger.Conditions>
+				<MultiDataTrigger.Setters>
+					<Setter Property="Source" Value="{StaticResource StarlightStepChargesUnavailable}"/>
+				</MultiDataTrigger.Setters>
+			</MultiDataTrigger>
 			<!-- EDIT HERE -->
 		</Style.Triggers>
 	</Style>
@@ -2804,6 +2818,15 @@
 			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/Tet42_Gunslinger/Shared/Resources/ico_classRes_GSAmmoOffhand_d.png</ImageSource>
 			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/Tet42_Gunslinger/Shared/Resources/ico_classRes_GSAmmoOffhand_spent.png</ImageSource>
 			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/Tet42_Gunslinger/Shared/Resources/ico_classRes_GSAmmoOffhand_missing.png</ImageSource>
+		</ControlTemplate.Resources>
+		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
+	<ControlTemplate x:Key="ActionResources.ActionGroup.StarlightStepChargesGroup" TargetType="ls:LSActionPoint">
+		<ControlTemplate.Resources>
+			<ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/MoriAstralElf/Shared/Resources/ico_StarlightStepCharges_h.png</ImageSource>
+			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/MoriAstralElf/Shared/Resources/ico_StarlightStepCharges_d.png</ImageSource>
+			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/MoriAstralElf/Shared/Resources/ico_StarlightStepCharges_spent.png</ImageSource>
+			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/MoriAstralElf/Shared/Resources/ico_StarlightStepCharges_missing.png</ImageSource>
 		</ControlTemplate.Resources>
 		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
 	</ControlTemplate>
@@ -4285,6 +4308,19 @@
 			<MultiDataTrigger>
 				<MultiDataTrigger.Conditions>
 					<Condition Binding="{Binding TypeId}" Value="GSAmmoOffhand"/>
+					<Condition Binding="{Binding Value, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}" Value="True"/>
+				</MultiDataTrigger.Conditions>
+				<MultiDataTrigger.Setters>
+					<Setter Property="Margin" Value="0,-15,0,0"/>
+				</MultiDataTrigger.Setters>
+			</MultiDataTrigger>
+			<DataTrigger Binding="{Binding TypeId}" Value="StarlightStepCharges">
+				<Setter Property="ActionPointTemplate" Value="{DynamicResource ActionResources.ActionGroup.StarlightStepChargesGroup}"/>
+				<Setter Property="ActionPointSize" Value="{DynamicResource ActionResources.ActionPointSize}" />
+			</DataTrigger>
+			<MultiDataTrigger>
+				<MultiDataTrigger.Conditions>
+					<Condition Binding="{Binding TypeId}" Value="StarlightStepCharges"/>	
 					<Condition Binding="{Binding Value, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}" Value="True"/>
 				</MultiDataTrigger.Conditions>
 				<MultiDataTrigger.Setters>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_c.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_c.xaml
@@ -839,5 +839,14 @@
 		</ControlTemplate.Resources>
 		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
 	</ControlTemplate>
+	<ControlTemplate x:Key="ActionResources.ActionGroup.StarlightStepChargesGroup" TargetType="ls:LSActionPoint">
+		<ControlTemplate.Resources>
+			<ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/MoriAstralElf/ActionResources_c/Icons/c_ico_mini_spellSlot_starlightstepcharges.png</ImageSource>
+			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/MoriAstralElf/ActionResources_c/Icons/c_ico_mini_spellSlot_starlightstepcharges.png</ImageSource>
+			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/MoriAstralElf/ActionResources_c/Icons/c_ico_mini_spellSlot_starlightstepcharges.png</ImageSource>
+			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/MoriAstralElf/ActionResources_c/Icons/c_ico_mini_spellSlot_starlightstepcharges.png</ImageSource>
+		</ControlTemplate.Resources>
+		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
 	<!-- EDIT HERE -->
 </ResourceDictionary>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
@@ -1088,6 +1088,17 @@
 				<Setter TargetName="LevelImage" Property="Width" Value="50"/>
 				<Setter TargetName="LevelImage" Property="Stretch" Value="Fill"/>
 			</DataTrigger>
+			<DataTrigger Binding="{Binding ActionResource.TypeId}" Value="StarlightStepCharges">
+				<Setter TargetName="ResourcePoints" Property="Visibility" Value="Collapsed"/>
+				<Setter TargetName="ResourcePointsStack" Property="Margin" Value="22,0,22,0"/>
+				<Setter TargetName="ResourceAmount" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="LevelImage" Property="Margin" Value="-10,0,-10,0"/>
+				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/MoriAstralElf/ActionResources_c/Icons/c_ico_mini_spellSlot_starlightstepcharges.png"/>
+				<Setter TargetName="LevelImage" Property="Height" Value="50"/>
+				<Setter TargetName="LevelImage" Property="Width" Value="50"/>
+				<Setter TargetName="LevelImage" Property="Stretch" Value="Fill"/>
+			</DataTrigger>
 			<!-- EDIT HERE -->
 
 			<!-- Please leave the below alone -->
@@ -1978,6 +1989,14 @@
 				<Setter TargetName="ResourceImage" Property="Fill">
 					<Setter.Value>
 						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/Tet42_Gunslinger/ActionResources_c/Icons/c_ico_classRes_GSAmmoOffhand_d.png" Stretch="Uniform"/>
+					</Setter.Value>
+				</Setter>
+				<Setter TargetName="ResourceImage" Property="Width" Value="50"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding TypeId}" Value="StarlightStepCharges">
+				<Setter TargetName="ResourceImage" Property="Fill">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/MoriAstralElf/ActionResources_c/Icons/c_ico_mini_spellSlot_starlightstepcharges.png" Stretch="Uniform"/>
 					</Setter.Value>
 				</Setter>
 				<Setter TargetName="ResourceImage" Property="Width" Value="50"/>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_RaceIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_RaceIcons.xaml
@@ -1293,7 +1293,13 @@
 					</Setter.Value>
 				</Setter>
 			</DataTrigger>
-			<!-- EDIT HERE -->
+			<DataTrigger Binding="{Binding Guid}" Value="58fcd76d-09fe-43d9-8829-bd2309ea6740">
+				<Setter Property="OpacityMask">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/MoriAstralElf/CC/icons_races/AstralElf.png"/>
+					</Setter.Value>
+				</Setter>
+			</DataTrigger>
 		</Style.Triggers>
 	</Style>
 </ResourceDictionary>


### PR DESCRIPTION
Hello! I just submitted a mod a to the Nexus called [Mori's Astral Elves](https://www.nexusmods.com/baldursgate3/mods/7718?tab=description). I added the race icon and some custom resource icons to the IUI library files for it. Please let me know if there's any issues/changes that need to be made. Thank you!