### PR TITLE
AscendantDragon5e mod action resource icons

### DIFF
--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons.xaml
@@ -347,6 +347,8 @@
 	<ImageSource x:Key="DarkCommunionUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/Possessed/Shared/Resources/ico_DarkCommunion_missing.png</ImageSource>
 	<ImageSource x:Key="FuryPointMerciless">pack://application:,,,/GustavNoesisGUI;component/Assets/MercilessBarbarianOverhaul/Shared/Resources/ico_classRes_FuryPointMerciless_d.png</ImageSource>
 	<ImageSource x:Key="FuryPointMercilessUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/MercilessBarbarianOverhaul/Shared/Resources/ico_classRes_FuryPointMerciless_missing.png</ImageSource>
+	<ImageSource x:Key="BreathoftheDragon">pack://application:,,,/GustavNoesisGUI;component/Assets/AscendantDragon5e/Shared/Resources/ico_classRes_BreathoftheDragon_d.png</ImageSource>
+	<ImageSource x:Key="BreathoftheDragonUnavailable">pack://application:,,,/GustavNoesisGUI;component/Assets/AscendantDragon5e/Shared/Resources/ico_classRes_BreathoftheDragon_missing.png</ImageSource>
 	<!-- EDIT HERE -->
 
 	<!-- This is the icon that appears on the tooltip -->
@@ -735,6 +737,9 @@
 			</DataTrigger>
 			<DataTrigger Binding="{Binding TypeId}" Value="FuryPointMerciless">
 				<Setter Property="Source" Value="{StaticResource FuryPointMerciless}"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding TypeId}" Value="BreathoftheDragonUse">
+				<Setter Property="Source" Value="{StaticResource BreathoftheDragon}"/>
 			</DataTrigger>
 			<!-- EDIT HERE -->
 		</Style.Triggers>
@@ -2405,6 +2410,17 @@
 				</MultiDataTrigger.Setters>
 			</MultiDataTrigger>
 
+			<MultiDataTrigger>
+				<MultiDataTrigger.Conditions>
+					<Condition Binding="{Binding TypeId}" Value="BreathoftheDragonUse"/>
+					<Condition Binding="{Binding Value}" Value="0"/>
+					<Condition Binding="{Binding IgnoreCost}" Value="False"/>
+				</MultiDataTrigger.Conditions>
+				<MultiDataTrigger.Setters>
+					<Setter Property="Source" Value="{StaticResource BreathoftheDragonUnavailable}"/>
+				</MultiDataTrigger.Setters>
+			</MultiDataTrigger>
+
 			<!-- EDIT HERE -->
 		</Style.Triggers>
 	</Style>
@@ -3695,6 +3711,15 @@
 		<ContentControl ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
 	</ControlTemplate>
 
+	<ControlTemplate x:Key="ActionResources.ActionGroup.BreathoftheDragonGroup" TargetType="ls:LSActionPoint">
+		<ControlTemplate.Resources>
+			<ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/AscendantDragon5e/Shared/Resources/ico_classRes_BreathoftheDragon_h.png</ImageSource>
+			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/AscendantDragon5e/Shared/Resources/ico_classRes_BreathoftheDragon_d.png</ImageSource>
+			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/AscendantDragon5e/Shared/Resources/ico_classRes_BreathoftheDragon_spent.png</ImageSource>
+			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/AscendantDragon5e/Shared/Resources/ico_classRes_BreathoftheDragon_missing.png</ImageSource>
+		</ControlTemplate.Resources>
+		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
 	<!-- EDIT HERE -->
 
 	<!-- Setup default styles that are inherited before changes are applied, do not touch these -->
@@ -5637,6 +5662,20 @@
 			<MultiDataTrigger>
 				<MultiDataTrigger.Conditions>
 					<Condition Binding="{Binding TypeId}" Value="FuryPointMerciless"/>
+					<Condition Binding="{Binding Value, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}" Value="True"/>
+				</MultiDataTrigger.Conditions>
+				<MultiDataTrigger.Setters>
+					<Setter Property="Margin" Value="0,-15,0,0"/>
+				</MultiDataTrigger.Setters>
+			</MultiDataTrigger>
+
+			<DataTrigger Binding="{Binding TypeId}" Value="BreathoftheDragonUse">
+				<Setter Property="ActionPointTemplate" Value="{DynamicResource ActionResources.ActionGroup.BreathoftheDragonGroup}"/>
+				<Setter Property="ActionPointSize" Value="{DynamicResource ActionResources.ActionPointSize}" />
+			</DataTrigger>
+			<MultiDataTrigger>
+				<MultiDataTrigger.Conditions>
+					<Condition Binding="{Binding TypeId}" Value="BreathoftheDragonUse"/>
 					<Condition Binding="{Binding Value, Converter={StaticResource GreaterThanConverter}, ConverterParameter=1}" Value="True"/>
 				</MultiDataTrigger.Conditions>
 				<MultiDataTrigger.Setters>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_c.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_c.xaml
@@ -1194,5 +1194,14 @@
 		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
 	</ControlTemplate>
 
+	<ControlTemplate x:Key="ActionResources.ActionGroup.BreathoftheDragonGroup" TargetType="ls:LSActionPoint">
+		<ControlTemplate.Resources>
+			<ImageSource x:Key="Highlight">/GustavNoesisGUI;component/Assets/AscendantDragon5e/ActionResources_c/Icons/c_ico_classRes_BreathoftheDragon_h.png</ImageSource>
+			<ImageSource x:Key="Available">/GustavNoesisGUI;component/Assets/AscendantDragon5e/ActionResources_c/Icons/c_ico_classRes_BreathoftheDragon_d.png</ImageSource>
+			<ImageSource x:Key="Used">/GustavNoesisGUI;component/Assets/AscendantDragon5e/ActionResources_c/Icons/c_ico_classRes_BreathoftheDragon_spent.png</ImageSource>
+			<ImageSource x:Key="Missing">/GustavNoesisGUI;component/Assets/AscendantDragon5e/ActionResources_c/Icons/c_ico_classRes_BreathoftheDragon_missing.png</ImageSource>
+		</ControlTemplate.Resources>
+		<ContentPresenter ContentTemplate="{StaticResource ActionResources.ActionGroup.ActionPoint}"/>
+	</ControlTemplate>
 	<!-- EDIT HERE -->
 </ResourceDictionary>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_k.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceIcons_k.xaml
@@ -71,6 +71,9 @@
 	<BitmapImage x:Key="SpellPointsResourceIcon" UriSource="pack://application:,,,/GustavNoesisGUI;component/Assets/WizardSpellPointVariant/CC/icons_resources/ico_classRes_SpellPointsResource.png" />
 	<BitmapImage x:Key="DarkCommunionIcon" UriSource="pack://application:,,,/GustavNoesisGUI;component/Assets/Possessed/CC/icons_resources/ico_classRes_DarkCommunion.png" />
 	<BitmapImage x:Key="FuryPointMercilessIcon" UriSource="pack://application:,,,/GustavNoesisGUI;component/Assets/MercilessBarbarianOverhaul/CC/icons_resources/ico_classRes_FuryPointMerciless.png" />
+	<BitmapImage x:Key="BreathoftheDragonIcon" UriSource="pack://application:,,,/GustavNoesisGUI;component/Assets/AscendantDragon5e/CC/icons_resources/ico_classRes_BreathoftheDragon.png" />
+	<BitmapImage x:Key="FightingSpiritIcon" UriSource="pack://application:,,,/GustavNoesisGUI;component/Assets/Samurai5e/CC/icons_resources/ico_classRes_FightingSpirit.png" />
+
 	<!-- EDIT HERE -->
 
 	<!-- Reference entries below -->
@@ -253,6 +256,12 @@
 			</DataTrigger>
 			<DataTrigger Binding="{Binding TypeId}" Value="FuryPointMerciless">
 				<Setter Property="Source" Value="{StaticResource FuryPointMercilessIcon}"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding TypeId}" Value="BreathoftheDragonUse">
+				<Setter Property="Source" Value="{StaticResource BreathoftheDragonIcon}"/>
+			</DataTrigger>
+			<DataTrigger Binding="{Binding TypeId}" Value="FightingSpiritUse">
+				<Setter Property="Source" Value="{StaticResource FightingSpiritIcon}"/>
 			</DataTrigger>
 			<!-- EDIT HERE -->
 		</Style.Triggers>

--- a/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
+++ b/ImprovedUI/Public/Game/GUI/Library/IUI_ActionResourceTemplates_c.xaml
@@ -1542,6 +1542,18 @@
 				<Setter TargetName="LevelImage" Property="Stretch" Value="Fill"/>
 			</DataTrigger>
 
+			<DataTrigger Binding="{Binding ActionResource.TypeId}" Value="BreathoftheDragonUse">
+				<Setter TargetName="ResourcePoints" Property="Visibility" Value="Collapsed"/>
+				<Setter TargetName="ResourcePointsStack" Property="Margin" Value="22,0,22,0"/>
+				<Setter TargetName="ResourceAmount" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="LevelImage" Property="Visibility" Value="Visible"/>
+				<Setter TargetName="LevelImage" Property="Margin" Value="-10,0,-10,0"/>
+				<Setter TargetName="LevelImage" Property="Source" Value="pack://application:,,,/GustavNoesisGUI;component/Assets/AscendantDragon5e/ActionResources_c/Icons/c_ico_classRes_BreathoftheDragon_d.png"/>
+				<Setter TargetName="LevelImage" Property="Height" Value="50"/>
+				<Setter TargetName="LevelImage" Property="Width" Value="50"/>
+				<Setter TargetName="LevelImage" Property="Stretch" Value="Fill"/>
+			</DataTrigger>
+
 			<!-- EDIT HERE -->
 
 			<!-- Please leave the below alone -->
@@ -2721,6 +2733,15 @@
 				<Setter TargetName="ResourceImage" Property="Width" Value="50"/>
 			</DataTrigger>
 
+			<DataTrigger Binding="{Binding TypeId}" Value="BreathoftheDragonUse">
+				<Setter TargetName="ResourceImage" Property="Fill">
+					<Setter.Value>
+						<ImageBrush ImageSource="pack://application:,,,/GustavNoesisGUI;component/Assets/AscendantDragon5e/ActionResources_c/Icons/c_ico_classRes_BreathoftheDragon_d.png" Stretch="Uniform"/>
+					</Setter.Value>
+				</Setter>
+				<Setter TargetName="ResourceImage" Property="Width" Value="50"/>
+			</DataTrigger>
+			
 			<!-- EDIT HERE -->
 
 			<DataTrigger Binding="{Binding Level}" Value="1">


### PR DESCRIPTION
Add support for action resource icons in mod (attached)
also fixed missing fighting spirit icon entry from CC for Samurai5e mod (https://www.nexusmods.com/baldursgate3/mods/7236)
[AscendantDragon5e.zip](https://github.com/user-attachments/files/16200007/AscendantDragon5e.zip)
